### PR TITLE
Update ancestor and children widget endpoints

### DIFF
--- a/src/widgets/PassageAncestorsWidget.vue
+++ b/src/widgets/PassageAncestorsWidget.vue
@@ -33,14 +33,14 @@
         return this.passage
           ? gql`
             {
-              passageLines(reference: "${this.passage.absolute}") {
+              passageTextParts(reference: "${this.passage.absolute}") {
                 metadata
               }
             }`
           : null;
       },
       ancestorsLens() {
-        return this.gqlData.passageLines.metadata.ancestors;
+        return this.gqlData.passageTextParts.metadata.ancestors;
       },
       ancestors() {
         return this.gqlData && this.ancestorsLens

--- a/src/widgets/PassageChildrenWidget.vue
+++ b/src/widgets/PassageChildrenWidget.vue
@@ -32,14 +32,14 @@
         return this.passage
           ? gql`
             {
-              passageLines(reference: "${this.passage.absolute}") {
+              passageTextParts(reference: "${this.passage.absolute}") {
                 metadata
               }
             }`
           : null;
       },
       childrenLens() {
-        return this.gqlData.passageLines.metadata.children;
+        return this.gqlData.passageTextParts.metadata.children;
       },
       children() {
         return this.gqlData && this.childrenLens


### PR DESCRIPTION
Changes necessary to synchronise with upstream ATLAS [`Node` work](https://github.com/scaife-viewer/explorehomer-atlas/pull/16).

See also: https://github.com/scaife-viewer/explorehomer/pull/2