### PR TITLE
Library Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,31 @@ Lint:
 ```sh
 $ npm run lint
 ```
+
+
+## Develop `scaife-widgets` in parallel with a Scaife Viewer front end:
+
+Within the `scaife-widgets` repo root directory:
+
+```sh
+$ yarn link # @@@ resolve npm / yarn difference between projects
+$ npm run watch
+```
+
+Within the Scaife Viewer front end directory:
+
+```sh
+$ yarn link "@scaife-viewer/scaife-widgets"
+$ yarn serve
+```
+
+The `watch` script will re-build `scaife-widgets` when changes are made.
+
+Since the module has been linked via `yarn link`, the front end's `serve` script will detect the changes and recompile the front end.
+
+To revert to the canonical `scaife-widgets` installation within the Scaife Viewer front end:
+
+```sh
+yarn unlink "scaife-viewer/scaife-widgets"
+yarn install --force
+```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "homepage": "https://github.com/scaife-viewer/scaife-widgets#readme",
   "main": "./dist/scaife-widgets.common.js",
   "scripts": {
+    "prepare": "npm run build",
     "build": "vue-cli-service build --target lib --name scaife-widgets ./src/index.js",
+    "watch": "vue-cli-service build --mode production --formats commonjs --target lib --name scaife-widgets ./src/index.js --watch",
     "test": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint"
   },

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -13,7 +13,7 @@
   };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   .hello {
     color: red;
   }

--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -1,13 +1,14 @@
 <template>
   <aside class="metadata-container u-flex">
     <h3 class="work-title">{{ workTitle }}</h3>
+    <tt class="work-urn">{{ workUrn }}</tt>
   </aside>
 </template>
 
 <script>
   export default {
     name: 'Metadata',
-    props: ['workTitle'],
+    props: ['workTitle', 'workUrn'],
   };
 </script>
 

--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -17,6 +17,6 @@
 <style scoped>
   h1.work-title {
     font-size: 1.75em;
-    margin: 0;
+    margin: 0 2em 1em 2em;
   }
 </style>

--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -1,22 +1,21 @@
-<template functional>
-  <h1 class="work-title">{{ props.workTitle }}</h1>
+<template>
+  <aside class="metadata-container u-flex">
+    <h3 class="work-title">{{ workTitle }}</h3>
+  </aside>
 </template>
 
 <script>
   export default {
     name: 'Metadata',
-    props: {
-      workTitle: {
-        required: true,
-        type: String,
-      },
-    },
+    props: ['workTitle'],
   };
 </script>
 
-<style scoped>
-  h1.work-title {
-    font-size: 1.75em;
-    margin: 0 2em 1em 2em;
+<style lang="scss" scoped>
+  .metadata-container {
+    flex-direction: column;
+    > * {
+      margin: 0 0 0.33em 0;
+    }
   }
 </style>

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -1,21 +1,23 @@
 <template>
   <li>
-    <template v-if="hasChildren">
-      <span class="open-toggle" @click.prevent="toggle">
-        <Icon :name="icon" class="fa-xs" fixed-width />
-      </span>
-    </template>
+    <div class="node-container u-flex">
+      <template v-if="hasChildren">
+        <span class="open-toggle" @click.prevent="toggle">
+          <Icon :name="icon" class="fa-xs" fixed-width />
+        </span>
+      </template>
 
-    <span class="node version" v-if="routable">
-      <router-link
-        :to="{ path: 'reader', query: { urn: metadata.firstPassageUrn } }"
-      >
-        {{ metadata.workTitle }}
-      </router-link>
-    </span>
-    <span v-else class="node monospace">
-      <tt>{{ urn }}</tt>
-    </span>
+      <span class="node version" v-if="routable">
+        <router-link
+          :to="{ path: 'reader', query: { urn: metadata.firstPassageUrn } }"
+        >
+          {{ metadata.workTitle }}
+        </router-link>
+      </span>
+      <span v-else class="node monospace">
+        <tt>{{ urn }}</tt>
+      </span>
+    </div>
 
     <ul class="node-tree" v-if="expanded">
       <Node
@@ -90,12 +92,8 @@
     }
   }
   .node {
-    font-size: 0.9rem;
-    &.monospace {
-      font-size: 1.1rem;
-    }
     &.version {
-      margin-left: 0.66em;
+      margin-left: 1em;
     }
   }
 </style>

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -1,0 +1,101 @@
+<template>
+  <li>
+    <template v-if="hasChildren">
+      <span class="open-toggle" @click.prevent="toggle">
+        <Icon :name="icon" class="fa-xs" fixed-width />
+      </span>
+    </template>
+
+    <span class="node version" v-if="routable">
+      <router-link
+        :to="{ path: 'reader', query: { urn: metadata.firstPassageUrn } }"
+      >
+        {{ metadata.workTitle }}
+      </router-link>
+    </span>
+    <span v-else class="node monospace">
+      <tt>{{ urn }}</tt>
+    </span>
+
+    <ul class="node-tree" v-if="expanded">
+      <Node
+        v-for="(node, index) in node.children"
+        :key="index"
+        :node="node"
+      ></Node>
+    </ul>
+  </li>
+</template>
+
+<script>
+  import Icon from '@/components/Icon.vue';
+
+  export default {
+    name: 'Node',
+    props: ['node'],
+    components: {
+      Icon,
+    },
+    data() {
+      return {
+        expanded: false,
+      };
+    },
+    computed: {
+      urn() {
+        // TODO: Cast to URN post-refactor.
+        return this.node.data.urn;
+      },
+      kind() {
+        return this.node.data.kind;
+      },
+      metadata() {
+        return this.node.data.metadata;
+      },
+      routable() {
+        return this.kind === 'version';
+      },
+      icon() {
+        return this.expanded ? 'chevron-down' : 'chevron-right';
+      },
+      hasChildren() {
+        return this.node.children && this.node.children.length;
+      },
+    },
+    methods: {
+      toggle() {
+        this.expanded = !this.expanded;
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  @import '@/styles/_variables.scss';
+
+  a {
+    text-decoration: none;
+  }
+  li {
+    margin-top: 0.33em;
+  }
+  span {
+    text-decoration: none;
+    &.open-toggle {
+      color: $gray-400;
+      padding: 0 0.33em 0 0;
+      &:hover {
+        color: $gray-700;
+      }
+    }
+  }
+  .node {
+    font-size: 0.9rem;
+    &.monospace {
+      font-size: 1.1rem;
+    }
+    &.version {
+      margin-left: 0.66em;
+    }
+  }
+</style>

--- a/src/components/Paginator.vue
+++ b/src/components/Paginator.vue
@@ -27,7 +27,7 @@
   };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   nav.paginator {
     min-width: 5em;
     width: auto;

--- a/src/components/Paginator.vue
+++ b/src/components/Paginator.vue
@@ -33,5 +33,6 @@
     width: auto;
     position: sticky;
     top: 2em;
+    text-align: center;
   }
 </style>

--- a/src/components/TextSize.vue
+++ b/src/components/TextSize.vue
@@ -20,14 +20,14 @@
 </script>
 
 <style lang="scss" scoped>
-@import "@/styles/_variables.scss";
+  @import '@/styles/_variables.scss';
 
-.text-size-control {
-  cursor: pointer;
-  font-family: $font-family-serif;
-  color: $gray-500;
-}
-.text-size-control.selected {
-  color: $gray-800;
-}
+  .text-size-control {
+    cursor: pointer;
+    font-family: $font-family-serif;
+    color: $gray-500;
+  }
+  .text-size-control.selected {
+    color: $gray-800;
+  }
 </style>

--- a/src/components/TextWidth.vue
+++ b/src/components/TextWidth.vue
@@ -22,17 +22,17 @@
 </script>
 
 <style lang="scss" scoped>
-@import "@/styles/_variables.scss";
+  @import '@/styles/_variables.scss';
 
-.text-width-control {
-  font-family: $font-family-serif;
-  cursor: pointer;
-  color: $gray-500;
-  font-size: 14px;
-  padding-right: 5px;
-}
+  .text-width-control {
+    font-family: $font-family-serif;
+    cursor: pointer;
+    color: $gray-500;
+    font-size: 14px;
+    padding-right: 5px;
+  }
 
-.text-width-control.active {
-  color: $gray-800;
-}
+  .text-width-control.active {
+    color: $gray-800;
+  }
 </style>

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,10 @@ export { default as TextWidth } from '@/components/TextWidth.vue';
 export { default as Icon } from '@/components/Icon.vue';
 
 // widgets
+export { default as LibraryWidget } from '@/widgets/LibraryWidget.vue';
+export { default as MetadataWidget } from '@/widgets/MetadataWidget.vue';
 export { default as TextSizeWidget } from '@/widgets/TextSizeWidget.vue';
 export { default as TextWidthWidget } from '@/widgets/TextWidthWidget.vue';
-export { default as LibraryWidget } from '@/widgets/LibraryWidget.vue';
 // eslint-disable-next-line max-len
 export { default as PassageAncestorsWidget } from '@/widgets/PassageAncestorsWidget.vue';
 // eslint-disable-next-line max-len

--- a/src/index.js
+++ b/src/index.js
@@ -14,13 +14,14 @@ export { default as Icon } from '@/components/Icon.vue';
 
 // widgets
 export { default as TextSizeWidget } from '@/widgets/TextSizeWidget.vue';
+export { default as TextWidthWidget } from '@/widgets/TextWidthWidget.vue';
+export { default as LibraryWidget } from '@/widgets/LibraryWidget.vue';
 // eslint-disable-next-line max-len
 export { default as PassageAncestorsWidget } from '@/widgets/PassageAncestorsWidget.vue';
 // eslint-disable-next-line max-len
 export { default as PassageChildrenWidget } from '@/widgets/PassageChildrenWidget.vue';
 // eslint-disable-next-line max-len
 export { default as PassageReferenceWidget } from '@/widgets/PassageReferenceWidget.vue';
-export { default as TextWidthWidget } from '@/widgets/TextWidthWidget.vue';
 
 // store
 export { default as scaifeWidgets } from '@/store';

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -4,4 +4,6 @@ export default {
   passage: (state, getters, rootState, rootGetters) => rootGetters.passage,
   firstPassageUrn: (state, getters, rootState, rootGetters) =>
     rootGetters.firstPassageUrn,
+  libraryTree: (state, getters, rootState, rootGetters) =>
+    rootGetters.libraryTree,
 };

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -6,4 +6,5 @@ export default {
     rootGetters.firstPassageUrn,
   libraryTree: (state, getters, rootState, rootGetters) =>
     rootGetters.libraryTree,
+  metadata: (state, getters, rootState, rootGetters) => rootGetters.metadata,
 };

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -30,3 +30,7 @@
 .text-width-full {
   max-width: 100%;
 }
+
+.u-widget {
+  margin: 0 2em;
+}

--- a/src/widgets/LibraryWidget.vue
+++ b/src/widgets/LibraryWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="library-widget u-flex">
+  <div class="library-widget u-widget u-flex">
     <ul class="node-tree root" v-if="libraryTree">
       <Node v-for="(node, index) in libraryTree" :key="index" :node="node" />
     </ul>
@@ -28,7 +28,7 @@
 
 <style lang="scss">
   .library-widget {
-    margin: 0 auto 0 0;
+    margin: 0 auto 0 2em;
     overflow: auto;
   }
   ul.node-tree {

--- a/src/widgets/LibraryWidget.vue
+++ b/src/widgets/LibraryWidget.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="library-widget u-flex">
+    <ul class="node-tree root" v-if="libraryTree">
+      <Node v-for="(node, index) in libraryTree" :key="index" :node="node" />
+    </ul>
+  </div>
+</template>
+
+<script>
+  import Node from '@/components/Node.vue';
+  import { WIDGETS_NS } from '@/store/constants';
+
+  export default {
+    name: 'LibraryWidget',
+    components: {
+      Node,
+    },
+    scaifeConfig: {
+      displayName: 'Library',
+    },
+    computed: {
+      libraryTree() {
+        return this.$store.getters[`${WIDGETS_NS}/libraryTree`];
+      },
+    },
+  };
+</script>
+
+<style lang="scss">
+  .library-widget {
+    margin: 0 auto 0 0;
+  }
+  ul.node-tree {
+    list-style: none;
+    padding: 0;
+    margin-left: 0.66em;
+    &.root {
+      margin: 0 0 0.33em 1.8em;
+    }
+  }
+</style>

--- a/src/widgets/LibraryWidget.vue
+++ b/src/widgets/LibraryWidget.vue
@@ -29,13 +29,15 @@
 <style lang="scss">
   .library-widget {
     margin: 0 auto 0 0;
+    overflow: auto;
   }
   ul.node-tree {
     list-style: none;
     padding: 0;
-    margin-left: 0.66em;
+    flex-wrap: nowrap;
+    margin-left: 0.33em;
     &.root {
-      margin: 0 0 0.33em 1.8em;
+      margin: 0 0 0.33em 0;
     }
   }
 </style>

--- a/src/widgets/MetadataWidget.vue
+++ b/src/widgets/MetadataWidget.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="metadata-widget u-widget u-flex">
+    <Metadata v-if="metadata" :workTitle="workTitle" />
+  </div>
+</template>
+
+<script>
+  import Metadata from '@/components/Metadata.vue';
+  import { WIDGETS_NS } from '@/store/constants';
+
+  export default {
+    name: 'MetadataWidget',
+    components: {
+      Metadata,
+    },
+    scaifeConfig: {
+      displayName: 'Metadata',
+    },
+    computed: {
+      metadata() {
+        return this.$store.getters[`${WIDGETS_NS}/metadata`];
+      },
+      workTitle() {
+        return this.metadata.workTitle;
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .metadata-widget {
+    justify-content: flex-start;
+    width: 100%;
+  }
+</style>

--- a/src/widgets/MetadataWidget.vue
+++ b/src/widgets/MetadataWidget.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="metadata-widget u-widget u-flex">
-    <Metadata v-if="metadata" :workTitle="workTitle" />
+    <Metadata v-if="metadata" :workTitle="workTitle" :workUrn="workUrn" />
   </div>
 </template>
 
@@ -22,6 +22,9 @@
       },
       workTitle() {
         return this.metadata.workTitle;
+      },
+      workUrn() {
+        return this.metadata.workUrn;
       },
     },
   };

--- a/src/widgets/PassageAncestorsWidget.vue
+++ b/src/widgets/PassageAncestorsWidget.vue
@@ -1,5 +1,5 @@
 <template v-if="ancestors">
-  <div class="passage-ancestors-widget u-grid">
+  <div class="passage-ancestors-widget u-widget u-grid">
     <div
       class="grid-cell-square"
       v-for="ancestor in ancestors"
@@ -51,14 +51,13 @@
   };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   a {
     text-decoration: none;
   }
   .passage-ancestors-widget {
     width: 100%;
-    margin: 0 0.33em;
-    margin: 0.5em 0 1em 0;
+    margin: 0 2em;
     grid-auto-rows: 1fr;
     grid-template-columns: repeat(auto-fill, minmax(1.6em, 1fr));
     grid-gap: 0.0825em;

--- a/src/widgets/PassageChildrenWidget.vue
+++ b/src/widgets/PassageChildrenWidget.vue
@@ -1,5 +1,5 @@
 <template v-if="children">
-  <div class="passage-children-widget u-grid">
+  <div class="passage-children-widget u-widget u-grid">
     <div
       class="grid-cell-square"
       v-for="child in children"
@@ -50,14 +50,12 @@
   };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   a {
     text-decoration: none;
   }
   .passage-children-widget {
     width: 100%;
-    margin: 0 0.33em;
-    margin: 0.5em 0 1em 0;
     grid-auto-rows: 1fr;
     grid-template-columns: repeat(auto-fill, minmax(1.6em, 1fr));
     grid-gap: 0.0825em;

--- a/src/widgets/PassageReferenceWidget.vue
+++ b/src/widgets/PassageReferenceWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="passage-reference-widget">
+  <div class="passage-reference-widget u-widget">
     <input
       v-model="reference"
       v-on:keyup="handleKeyUp"
@@ -65,7 +65,7 @@
   };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   .passage-reference-widget {
     margin: 0 2em;
     flex: 1;

--- a/src/widgets/TextSizeWidget.vue
+++ b/src/widgets/TextSizeWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-size-widget">
+  <div class="text-size-widget u-widget">
     <TextSize :value="textSize" @input="changeTextSize" size="xs" />{{ ' ' }}
     <TextSize :value="textSize" @input="changeTextSize" size="sm" />{{ ' ' }}
     <TextSize :value="textSize" @input="changeTextSize" size="md" />{{ ' ' }}
@@ -34,7 +34,7 @@
   };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   .text-size-widget {
     margin: 0 2em;
     flex: 1;

--- a/src/widgets/TextWidthWidget.vue
+++ b/src/widgets/TextWidthWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-width-widget">
+  <div class="text-width-widget u-widget">
     <TextWidth :value="textWidth" @input="changeTextWidth" width="narrow" />
     <TextWidth :value="textWidth" @input="changeTextWidth" width="normal" />
     <TextWidth :value="textWidth" @input="changeTextWidth" width="wide" />
@@ -30,7 +30,7 @@
   };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   .text-width-widget {
     margin: 0 2em;
     flex: 1;

--- a/tests/components/Metadata.spec.js
+++ b/tests/components/Metadata.spec.js
@@ -5,9 +5,10 @@ import Metadata from '@/components/Metadata.vue';
 describe('Metadata.vue', () => {
   it('it renders the work title', () => {
     const wrapper = shallowMount(Metadata, {
-      propsData: { workTitle: 'some title' },
+      propsData: { workTitle: 'some title', workUrn: 'urn:cts:1:1.1:' },
     });
 
     expect(wrapper.html()).toContain('<h3 class="work-title">some title</h3>');
+    expect(wrapper.html()).toContain('<tt class="work-urn">urn:cts:1:1.1:</tt>');
   });
 });

--- a/tests/components/Metadata.spec.js
+++ b/tests/components/Metadata.spec.js
@@ -5,9 +5,9 @@ import Metadata from '@/components/Metadata.vue';
 describe('Metadata.vue', () => {
   it('it renders the work title', () => {
     const wrapper = shallowMount(Metadata, {
-      context: { props: { workTitle: 'Some Title' } },
+      propsData: { workTitle: 'some title' },
     });
 
-    expect(wrapper.html()).toBe('<h1 class="work-title">Some Title</h1>');
+    expect(wrapper.html()).toContain('<h3 class="work-title">some title</h3>');
   });
 });

--- a/tests/components/Node.spec.js
+++ b/tests/components/Node.spec.js
@@ -1,0 +1,120 @@
+/* global describe, expect, it  */
+import { mount, shallowMount, RouterLinkStub } from '@vue/test-utils';
+import Node from '@/components/Node.vue';
+
+describe('Node.vue', () => {
+  it('It renders nodes without children.', () => {
+    const node = {
+      data: { urn: 'urn:cts:1:', kind: 'node', metadata: {} },
+      children: [],
+    };
+    const wrapper = shallowMount(Node, { propsData: { node } });
+
+    expect(wrapper.html()).not.toContain('<span class="open-toggle"');
+    expect(wrapper.html()).toContain(
+      '<span class="node monospace"><tt>urn:cts:1:</tt></span>',
+    );
+    expect(wrapper.html()).not.toContain('<a>');
+    expect(wrapper.html()).not.toContain('<ul class="node-tree"');
+  });
+
+  it('It renders routable version nodes without children.', () => {
+    const node = {
+      data: {
+        urn: 'urn:cts:1:1.1.1:',
+        kind: 'version',
+        metadata: {
+          workTitle: 'some title',
+          firstPassageUrn: 'urn:cts:1:1.1.1:1',
+        },
+      },
+      children: [],
+    };
+    const wrapper = shallowMount(Node, {
+      propsData: { node },
+      stubs: { RouterLink: RouterLinkStub },
+    });
+
+    expect(wrapper.html()).not.toContain('<span class="open-toggle"');
+    expect(wrapper.html()).toContain('<span class="node version">');
+    const route = wrapper.find('a');
+    expect(route.text()).toBe('some title');
+    expect(wrapper.html()).not.toContain('<ul class="node-tree"');
+  });
+
+  it('It does not render children when parent node not expanded.', () => {
+    const node = {
+      data: { urn: 'urn:cts:1:1.1:', kind: 'node', metadata: {} },
+      children: [
+        {
+          data: {
+            urn: 'urn:cts:1:1.1.1:',
+            kind: 'version',
+            metadata: {
+              workTitle: 'some title',
+              firstPassageUrn: 'urn:cts:1:1.1.1:1',
+            },
+          },
+          children: [],
+        },
+      ],
+    };
+    const wrapper = shallowMount(Node, {
+      propsData: { node },
+      stubs: { RouterLink: RouterLinkStub },
+    });
+
+    const spans = wrapper.findAll('span');
+    expect(spans.at(0).classes()).toStrictEqual(['open-toggle']);
+    expect(spans.at(1).classes()).toStrictEqual(['node', 'monospace']);
+    const monospace = wrapper.findAll('tt');
+    expect(monospace.length).toBe(1);
+    expect(monospace.at(0).text()).toBe('urn:cts:1:1.1:');
+
+    const childList = wrapper.findAll('ul');
+    expect(childList.length).toBe(0);
+  });
+
+  it('It renders all nodes when expanded.', async () => {
+    const node = {
+      data: { urn: 'urn:cts:1:1.1:', kind: 'node', metadata: {} },
+      children: [
+        {
+          data: {
+            urn: 'urn:cts:1:1.1.1:',
+            kind: 'version',
+            metadata: {
+              workTitle: 'some title',
+              firstPassageUrn: 'urn:cts:1:1.1.1:1',
+            },
+          },
+          children: [],
+        },
+      ],
+    };
+    // Use a full mount here so we can see the recursion happen.
+    const wrapper = mount(Node, {
+      propsData: { node },
+      stubs: { RouterLink: RouterLinkStub },
+    });
+    const toggle = wrapper.find('span');
+    toggle.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const spans = wrapper.findAll('span');
+    expect(spans.at(0).classes()).toStrictEqual(['open-toggle']);
+    expect(spans.at(1).classes()).toStrictEqual(['node', 'monospace']);
+    const monospace = wrapper.findAll('tt');
+    expect(monospace.length).toBe(1);
+    expect(monospace.at(0).text()).toBe('urn:cts:1:1.1:');
+
+    const childList = wrapper.findAll('ul');
+    expect(childList.length).toBe(1);
+    expect(childList.at(0).classes()).toStrictEqual(['node-tree']);
+    expect(spans.at(2).classes()).toStrictEqual(['node', 'version']);
+
+    const route = wrapper.findAll('a');
+    expect(route.length).toBe(1);
+    expect(route.at(0).text()).toBe('some title');
+  });
+});

--- a/tests/widgets/LibraryWidget.spec.js
+++ b/tests/widgets/LibraryWidget.spec.js
@@ -1,0 +1,38 @@
+/* global describe, expect, it  */
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import scaifeWidgets from '@/store';
+import LibraryWidget from '@/widgets/LibraryWidget.vue';
+import Node from '@/components/Node.vue';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('LibraryWidget.vue', () => {
+  it('Passes props and renders a Node tree.', () => {
+    const store = new Vuex.Store({
+      modules: {
+        [scaifeWidgets.namespace]: scaifeWidgets.store,
+      },
+    });
+    const wrapper = shallowMount(LibraryWidget, {
+      store,
+      localVue,
+      computed: {
+        libraryTree() {
+          return [{ some: 'data' }];
+        },
+      },
+    });
+    const container = wrapper.find('div');
+    expect(container.classes()).toContain('library-widget');
+
+    const root = wrapper.find('ul');
+    expect(root.classes()).toStrictEqual(['node-tree', 'root']);
+
+    expect(wrapper.find(Node).props()).toStrictEqual({
+      node: { some: 'data' },
+    });
+  });
+});

--- a/tests/widgets/MetadataWidget.spec.js
+++ b/tests/widgets/MetadataWidget.spec.js
@@ -1,0 +1,35 @@
+/* global describe, expect, it  */
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import scaifeWidgets from '@/store';
+import MetadataWidget from '@/widgets/MetadataWidget.vue';
+import Metadata from '@/components/Metadata.vue';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('MetadataWidget.vue', () => {
+  it('Passes props and renders Metadata.', () => {
+    const store = new Vuex.Store({
+      modules: {
+        [scaifeWidgets.namespace]: scaifeWidgets.store,
+      },
+    });
+    const wrapper = shallowMount(MetadataWidget, {
+      store,
+      localVue,
+      computed: {
+        metadata() {
+          return { workTitle: 'some title' };
+        },
+      },
+    });
+    const container = wrapper.find('div');
+    expect(container.classes()).toContain('metadata-widget');
+
+    expect(wrapper.find(Metadata).props()).toStrictEqual({
+      workTitle: 'some title',
+    });
+  });
+});

--- a/tests/widgets/MetadataWidget.spec.js
+++ b/tests/widgets/MetadataWidget.spec.js
@@ -21,7 +21,7 @@ describe('MetadataWidget.vue', () => {
       localVue,
       computed: {
         metadata() {
-          return { workTitle: 'some title' };
+          return { workTitle: 'some title', workUrn: 'urn:cts:1:1.1:' };
         },
       },
     });
@@ -30,6 +30,7 @@ describe('MetadataWidget.vue', () => {
 
     expect(wrapper.find(Metadata).props()).toStrictEqual({
       workTitle: 'some title',
+      workUrn: 'urn:cts:1:1.1:',
     });
   });
 });

--- a/tests/widgets/PassageAncestorsWidget.spec.js
+++ b/tests/widgets/PassageAncestorsWidget.spec.js
@@ -28,7 +28,7 @@ describe('PassageAncestorsWidget.vue', () => {
     });
 
     expect(wrapper.html()).toBe(
-      '<div class="passage-ancestors-widget u-grid"></div>',
+      '<div class="passage-ancestors-widget u-widget u-grid"></div>',
     );
   });
 

--- a/tests/widgets/PassageChildrenWidget.spec.js
+++ b/tests/widgets/PassageChildrenWidget.spec.js
@@ -28,7 +28,7 @@ describe('PassageChildrenWidget.vue', () => {
     });
 
     expect(wrapper.html()).toBe(
-      '<div class="passage-children-widget u-grid"></div>',
+      '<div class="passage-children-widget u-widget u-grid"></div>',
     );
   });
 

--- a/tests/widgets/TextSizeWidget.spec.js
+++ b/tests/widgets/TextSizeWidget.spec.js
@@ -24,8 +24,7 @@ describe('TextSizeWidget.vue', () => {
     });
 
     expect(wrapper.html()).toContain(
-      // eslint-disable-next-line max-len
-      '<div class="text-size-widget"><textsize-stub size="xs" value="md"></textsize-stub>',
+      '<textsize-stub size="xs" value="md"></textsize-stub>',
     );
     expect(store.state[WIDGETS_NS].readerTextSize).toBe('md');
   });
@@ -38,32 +37,27 @@ describe('TextSizeWidget.vue', () => {
     });
 
     expect(wrapper.html()).toContain(
-      // eslint-disable-next-line max-len
-      '<div class="text-size-widget"><textsize-stub size="xs" value="md"></textsize-stub>',
+      '<textsize-stub size="xs" value="md"></textsize-stub>',
     );
     expect(store.state[WIDGETS_NS].readerTextSize).toBe('md');
     store.dispatch(`${WIDGETS_NS}/${SET_TEXT_SIZE}`, { size: 'sm' });
     expect(wrapper.html()).toContain(
-      // eslint-disable-next-line max-len
-      '<div class="text-size-widget"><textsize-stub size="xs" value="sm"></textsize-stub>',
+      '<textsize-stub size="xs" value="sm"></textsize-stub>',
     );
     expect(store.state[WIDGETS_NS].readerTextSize).toBe('sm');
     store.dispatch(`${WIDGETS_NS}/${SET_TEXT_SIZE}`, { size: 'lg' });
     expect(wrapper.html()).toContain(
-      // eslint-disable-next-line max-len
-      '<div class="text-size-widget"><textsize-stub size="xs" value="lg"></textsize-stub>',
+      '<textsize-stub size="xs" value="lg"></textsize-stub>',
     );
     expect(store.state[WIDGETS_NS].readerTextSize).toBe('lg');
     store.dispatch(`${WIDGETS_NS}/${SET_TEXT_SIZE}`, { size: 'xl' });
     expect(wrapper.html()).toContain(
-      // eslint-disable-next-line max-len
-      '<div class="text-size-widget"><textsize-stub size="xs" value="xl"></textsize-stub>',
+      '<textsize-stub size="xs" value="xl"></textsize-stub>',
     );
     expect(store.state[WIDGETS_NS].readerTextSize).toBe('xl');
     store.dispatch(`${WIDGETS_NS}/${SET_TEXT_SIZE}`, { size: 'md' });
     expect(wrapper.html()).toContain(
-      // eslint-disable-next-line max-len
-      '<div class="text-size-widget"><textsize-stub size="xs" value="md"></textsize-stub>',
+      '<textsize-stub size="xs" value="md"></textsize-stub>',
     );
     expect(store.state[WIDGETS_NS].readerTextSize).toBe('md');
 


### PR DESCRIPTION
- Implement a `LibraryWidget` that consumes a library tree of node data and renders itself via a recursive `Node` component. Currently only `Version` nodes display their actual title (and are routable) the rest fall back on rendering their `URN` as a label. This is just until we have resolved the metadata ingestion questions we discussed on the call this week.
- Nodes with children are expandable and collapsable.
- Tested @mjhea0 style by copying the `dist` folder and necessary files into `sv-mini` local `node_modules` and it tests out fine. However, we should probably also repeat the previous release candidate cycle before we finally tag and release in full.

### Notes
- A quick search field to filter the tree would be a nice addition.

### Related PRs
- https://github.com/scaife-viewer/sv-mini-atlas/pull/5
- https://github.com/scaife-viewer/sv-mini/pull/1