### PR TITLE
Improve dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,31 @@ Lint:
 ```sh
 $ npm run lint
 ```
+
+
+## Develop `scaife-widgets` in parallel with a Scaife Viewer front end:
+
+Within the `scaife-widgets` repo root directory:
+
+```sh
+$ yarn link # @@@ resolve npm / yarn difference between projects
+$ npm run watch
+```
+
+Within the Scaife Viewer front end directory:
+
+```sh
+$ yarn link "@scaife-viewer/scaife-widgets"
+$ yarn serve
+```
+
+The `watch` script will re-build `scaife-widgets` when changes are made.
+
+Since the module has been linked via `yarn link`, the front end's `serve` script will detect the changes and recompile the front end.
+
+To revert to the canonical `scaife-widgets` installation within the Scaife Viewer front end:
+
+```sh
+yarn unlink "scaife-viewer/scaife-widgets"
+yarn install --force
+```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/scaife-viewer/scaife-widgets#readme",
   "main": "./dist/scaife-widgets.common.js",
   "scripts": {
+    "prepare": "npm run build",
     "build": "vue-cli-service build --target lib --name scaife-widgets ./src/index.js",
     "watch": "vue-cli-service build --mode production --formats commonjs --target lib --name scaife-widgets ./src/index.js --watch",
     "test": "vue-cli-service test:unit",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "./dist/scaife-widgets.common.js",
   "scripts": {
     "build": "vue-cli-service build --target lib --name scaife-widgets ./src/index.js",
+    "watch": "vue-cli-service build --mode production --formats commonjs --target lib --name scaife-widgets ./src/index.js --watch",
     "test": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint"
   },


### PR DESCRIPTION
The project configuration excludes the `dist` directory from Git.

Our release process (documented [in the wiki](https://github.com/scaife-viewer/scaife-widgets/wiki/Release-Process)) assumed that the package had been built via `npm run build`.

By defining a `prepare` script in package.json, we ensure that `npm run build` is always triggered as part of publishing to NPM.

The `prepare` script is also ran when installing the project via Git, so it is now possible for us to pin a Scaife Viewer front end to a particular branch or SHA, as demonstrated in [scaife-viewer/sv-mini#3](https://github.com/scaife-viewer/sv-mini/pull/3).

Adding a `watch` script and tweaking the webpack configuration for our front ends (see [scaife-viewer/sv-mini#4](https://github.com/scaife-viewer/sv-mini/pull/4)) also improves our local development story.  See `README.md` for further instructions.