### PR TITLE
Table Of Contents 2

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -7,6 +7,9 @@
 <script>
   export default {
     name: 'HelloWorld',
+    scaifeConfig: {
+      displayName: 'Hello, World',
+    },
     props: {
       msg: String,
     },

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -4,10 +4,15 @@
     <p>{{ toc.description }}</p>
     <ul>
       <li class="u-flex" v-for="(item, index) in toc.items" :key="index">
-        <span>{{ index + 1 }}.</span>
-        <router-link :to="{ path: 'reader', query: { urn: item.uri } }">
-          {{ item.title }}
-        </router-link>
+        <span class="ref">{{ index + 1 }}.</span>
+        <div class="item u-flex">
+          <router-link :to="{ path: 'reader', query: { urn: item.uri } }">
+            {{ item.title }}
+          </router-link>
+          <span>
+            <tt>{{ item.uri }}</tt>
+          </span>
+        </div>
       </li>
     </ul>
   </aside>
@@ -24,6 +29,7 @@
   .toc-container {
     align-items: flex-start;
     flex-direction: column;
+    width: 100%;
   }
   p {
     margin: 0.66em 0;
@@ -31,19 +37,26 @@
   ul {
     margin: 0;
     padding: 0;
+    width: 100%;
   }
   li {
-    align-items: center;
+    align-items: baseline;
     margin-bottom: 0.33em;
-    span {
+    span.ref {
       font-size: 10pt;
       color: #69c;
       font-family: 'Noto Sans';
       text-align: right;
       min-width: 2em;
     }
-    a {
+  }
+  .item {
+    flex-wrap: wrap;
+    width: 100%;
+    > * {
       margin-left: 1em;
+      flex-shrink: 0;
+      flex: 1 0 48%;
     }
   }
 </style>

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -6,7 +6,12 @@
       <li class="u-flex" v-for="(item, index) in toc.items" :key="index">
         <span class="ref">{{ index + 1 }}.</span>
         <div class="item u-flex">
-          <router-link :to="{ path: 'reader', query: { urn: item.uri } }">
+          <router-link
+            :to="{
+              path: isCiteUrn(item.uri) ? 'tocs' : 'reader',
+              query: { urn: item.uri },
+            }"
+          >
             {{ item.title }}
           </router-link>
           <span>
@@ -22,6 +27,11 @@
   export default {
     name: 'TOC',
     props: ['toc'],
+    methods: {
+      isCiteUrn(urn) {
+        return urn.startsWith('urn:cite:');
+      },
+    },
   };
 </script>
 

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -16,6 +16,9 @@
     created() {
       this.fetchData(this.url);
     },
+    watch: {
+      $route: 'fetchData',
+    },
     data() {
       return {
         toc: null,
@@ -29,17 +32,13 @@
         return `${this.endpoint}/tocs/demo-root.json`;
       },
       url() {
-        // TODO: Temporary (hack) logic until the TOC API hardens.
         if (this.$route.name === 'reader') {
-          // TODO: Some kind of version specific TOC lookup logic here.
+          // TODO: Some kind of version specific TOC lookup logic goes here.
           return `${this.endpoint}/tocs/toc.oaf-1.json`;
         }
-        const tocMap = {
-          1: `${this.endpoint}/tocs/toc.oaf-1.json`,
-          2: `${this.endpoint}/tocs/toc.crito-stephanus-jkt-1`,
-        };
-        return this.$route.query.id
-          ? tocMap[this.$route.query.id]
+        const urn = this.$route.query ? this.$route.query.urn : false;
+        return urn
+          ? `${this.endpoint}/tocs/${urn.split(':').slice(-1)}.json`
           : this.rootToc;
       },
     },

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -26,10 +26,10 @@
     },
     computed: {
       endpoint() {
-        return 'https://sv-mini-atlas.herokuapp.com';
+        return 'https://mini-stack-a-feature-se-j47yu0.herokuapp.com';
       },
       rootToc() {
-        return `${this.endpoint}/tocs/demo-root.json`;
+        return `${this.endpoint}/tocs/toc.demo-root.json`;
       },
       url() {
         if (this.$route.name === 'reader') {

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -23,20 +23,24 @@
     },
     computed: {
       endpoint() {
-        return 'https://sv-mini-atlas.herokuapp.com/tocs';
+        return 'https://sv-mini-atlas.herokuapp.com';
+      },
+      rootToc() {
+        return `${this.endpoint}/tocs/demo-root.json`;
       },
       url() {
-        // TODO: Temporary logic until the TOC API hardens.
+        // TODO: Temporary (hack) logic until the TOC API hardens.
         if (this.$route.name === 'reader') {
           // TODO: Some kind of version specific TOC lookup logic here.
-          return `${this.endpoint}/toc.oaf-1.json`;
+          return `${this.endpoint}/tocs/toc.oaf-1.json`;
         }
-        const rootToc = `${this.endpoint}/toc.demo-root.json`;
         const tocMap = {
-          1: `${this.endpoint}/toc.oaf-1.json`,
-          2: `${this.endpoint}/toc.crito-stephanus-jkt-1`,
+          1: `${this.endpoint}/tocs/toc.oaf-1.json`,
+          2: `${this.endpoint}/tocs/toc.crito-stephanus-jkt-1`,
         };
-        return this.$route.query.id ? tocMap[this.$route.query.id] : rootToc;
+        return this.$route.query.id
+          ? tocMap[this.$route.query.id]
+          : this.rootToc;
       },
     },
     methods: {

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -22,13 +22,26 @@
       };
     },
     computed: {
+      endpoint() {
+        return 'https://sv-mini-atlas.herokuapp.com/tocs';
+      },
       url() {
-        return 'https://sv-mini-atlas.herokuapp.com/tocs/toc.oaf-1.json';
+        // TODO: Temporary logic until the TOC API hardens.
+        if (this.$route.name === 'reader') {
+          // TODO: Some kind of version specific TOC lookup logic here.
+          return `${this.endpoint}/toc.oaf-1.json`;
+        }
+        const rootToc = `${this.endpoint}/toc.demo-root.json`;
+        const tocMap = {
+          1: `${this.endpoint}/toc.oaf-1.json`,
+          2: `${this.endpoint}/toc.crito-stephanus-jkt-1`,
+        };
+        return this.$route.query.id ? tocMap[this.$route.query.id] : rootToc;
       },
     },
     methods: {
-      fetchData(url) {
-        fetch(url)
+      fetchData() {
+        fetch(this.url)
           .then(response => response.json())
           .then(data => {
             this.toc = data;

--- a/tests/components/TOC.spec.js
+++ b/tests/components/TOC.spec.js
@@ -30,10 +30,10 @@ describe('TOC.vue', () => {
       '<p>A test fixture for a table of contents.</p>',
     );
 
-    const indexes = wrapper.findAll('span');
-    expect(indexes.length).toBe(2);
-    expect(indexes.at(0).text()).toBe('1.');
-    expect(indexes.at(1).text()).toBe('2.');
+    const refs = wrapper.findAll('span');
+    expect(refs.length).toBe(4);
+    expect(refs.at(0).text()).toBe('1.');
+    expect(refs.at(2).text()).toBe('2.');
 
     const titles = wrapper.findAll('a');
     expect(titles.length).toBe(2);
@@ -47,5 +47,10 @@ describe('TOC.vue', () => {
       path: 'reader',
       query: { urn: 'urn:cts:1:1.1.2:1-2' },
     });
+
+    const urns = wrapper.findAll('tt');
+    expect(urns.length).toBe(2);
+    expect(urns.at(0).text()).toBe('urn:cts:1:1.1.1:1-2');
+    expect(urns.at(1).text()).toBe('urn:cts:1:1.1.2:1-2');
   });
 });

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -26,7 +26,7 @@ const toc = {
 };
 
 describe('TOCWidget.vue', () => {
-  it('Parses a URL, passes props and renders a TOC.', () => {
+  it('Parses a URL, passes props and renders a TOC on the reader.', () => {
     const fetchData = jest.fn();
     const $route = { name: 'reader' };
 
@@ -52,9 +52,38 @@ describe('TOCWidget.vue', () => {
     expect(wrapper.find(TOC).props()).toStrictEqual({ toc: toc });
   });
 
+  it('Renders the root TOC when no query is given', () => {
+    const fetchData = jest.fn();
+    const $route = { name: 'tocs' };
+
+    const store = new Vuex.Store({
+      modules: {
+        [scaifeWidgets.namespace]: scaifeWidgets.store,
+      },
+    });
+    const wrapper = shallowMount(TOCWidget, {
+      store,
+      localVue,
+      methods: { fetchData },
+      mocks: { $route },
+    });
+    wrapper.setData({ toc });
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://sv-mini-atlas.herokuapp.com/tocs/demo-root.json',
+    );
+
+    const container = wrapper.find('div');
+    expect(container.classes()).toContain('toc-widget');
+    expect(wrapper.find(TOC).props()).toStrictEqual({ toc: toc });
+  });
+
   it('Conditionally renders a TOC based on the route and query.', () => {
     const fetchData = jest.fn();
-    const $route = { name: 'tocs', query: { id: 1 } };
+    const $route = {
+      name: 'tocs',
+      query: { urn: 'urn:cite:scaife-viewer:toc.oaf-1' },
+    };
 
     const store = new Vuex.Store({
       modules: {
@@ -71,32 +100,6 @@ describe('TOCWidget.vue', () => {
 
     expect(fetchData).toHaveBeenCalledWith(
       'https://sv-mini-atlas.herokuapp.com/tocs/toc.oaf-1.json',
-    );
-
-    const container = wrapper.find('div');
-    expect(container.classes()).toContain('toc-widget');
-    expect(wrapper.find(TOC).props()).toStrictEqual({ toc: toc });
-  });
-
-  it('Conditionally renders a TOC based on the route and query.', () => {
-    const fetchData = jest.fn();
-    const $route = { name: 'tocs', query: { id: 2 } };
-
-    const store = new Vuex.Store({
-      modules: {
-        [scaifeWidgets.namespace]: scaifeWidgets.store,
-      },
-    });
-    const wrapper = shallowMount(TOCWidget, {
-      store,
-      localVue,
-      methods: { fetchData },
-      mocks: { $route },
-    });
-    wrapper.setData({ toc });
-
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://sv-mini-atlas.herokuapp.com/tocs/toc.crito-stephanus-jkt-1',
     );
 
     const container = wrapper.find('div');

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -9,6 +9,7 @@ import TOC from '@/components/TOC.vue';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
+const endpoint = 'https://mini-stack-a-feature-se-j47yu0.herokuapp.com';
 const toc = {
   '@id': 'urn:cite:scaife-viewer:toc.1',
   title: 'Some Table of Contents',
@@ -43,9 +44,7 @@ describe('TOCWidget.vue', () => {
     });
     wrapper.setData({ toc });
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://sv-mini-atlas.herokuapp.com/tocs/toc.oaf-1.json',
-    );
+    expect(fetchData).toHaveBeenCalledWith(`${endpoint}/tocs/toc.oaf-1.json`);
 
     const container = wrapper.find('div');
     expect(container.classes()).toContain('toc-widget');
@@ -70,7 +69,7 @@ describe('TOCWidget.vue', () => {
     wrapper.setData({ toc });
 
     expect(fetchData).toHaveBeenCalledWith(
-      'https://sv-mini-atlas.herokuapp.com/tocs/demo-root.json',
+      `${endpoint}/tocs/toc.demo-root.json`,
     );
 
     const container = wrapper.find('div');
@@ -98,9 +97,7 @@ describe('TOCWidget.vue', () => {
     });
     wrapper.setData({ toc });
 
-    expect(fetchData).toHaveBeenCalledWith(
-      'https://sv-mini-atlas.herokuapp.com/tocs/toc.oaf-1.json',
-    );
+    expect(fetchData).toHaveBeenCalledWith(`${endpoint}/tocs/toc.oaf-1.json`);
 
     const container = wrapper.find('div');
     expect(container.classes()).toContain('toc-widget');

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -28,6 +28,7 @@ const toc = {
 describe('TOCWidget.vue', () => {
   it('Parses a URL, passes props and renders a TOC.', () => {
     const fetchData = jest.fn();
+    const $route = { name: 'reader' };
 
     const store = new Vuex.Store({
       modules: {
@@ -38,11 +39,64 @@ describe('TOCWidget.vue', () => {
       store,
       localVue,
       methods: { fetchData },
+      mocks: { $route },
     });
     wrapper.setData({ toc });
 
     expect(fetchData).toHaveBeenCalledWith(
       'https://sv-mini-atlas.herokuapp.com/tocs/toc.oaf-1.json',
+    );
+
+    const container = wrapper.find('div');
+    expect(container.classes()).toContain('toc-widget');
+    expect(wrapper.find(TOC).props()).toStrictEqual({ toc: toc });
+  });
+
+  it('Conditionally renders a TOC based on the route and query.', () => {
+    const fetchData = jest.fn();
+    const $route = { name: 'tocs', query: { id: 1 } };
+
+    const store = new Vuex.Store({
+      modules: {
+        [scaifeWidgets.namespace]: scaifeWidgets.store,
+      },
+    });
+    const wrapper = shallowMount(TOCWidget, {
+      store,
+      localVue,
+      methods: { fetchData },
+      mocks: { $route },
+    });
+    wrapper.setData({ toc });
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://sv-mini-atlas.herokuapp.com/tocs/toc.oaf-1.json',
+    );
+
+    const container = wrapper.find('div');
+    expect(container.classes()).toContain('toc-widget');
+    expect(wrapper.find(TOC).props()).toStrictEqual({ toc: toc });
+  });
+
+  it('Conditionally renders a TOC based on the route and query.', () => {
+    const fetchData = jest.fn();
+    const $route = { name: 'tocs', query: { id: 2 } };
+
+    const store = new Vuex.Store({
+      modules: {
+        [scaifeWidgets.namespace]: scaifeWidgets.store,
+      },
+    });
+    const wrapper = shallowMount(TOCWidget, {
+      store,
+      localVue,
+      methods: { fetchData },
+      mocks: { $route },
+    });
+    wrapper.setData({ toc });
+
+    expect(fetchData).toHaveBeenCalledWith(
+      'https://sv-mini-atlas.herokuapp.com/tocs/toc.crito-stephanus-jkt-1',
     );
 
     const container = wrapper.find('div');


### PR DESCRIPTION
https://trello.com/c/DvI45DcB/54-as-a-reader-i-can-view-a-stand-alone-toc

- Alter `TOCWidget` for reuse as the main widget on the TOC view.
- Add (very) provisional endpoint handling for differences in TOC page and widget load phases. 
- Render TOC item `URN` along with the title.

### Notes
- Do we want to add any kind of error/404 handling flow? Redirect to the root toc if 404 occurs?
- It's not possible to conditionally render a widget's title attribute based on context at the moment. It's either hardcoded on or off (if set as empty) in the component definition. We could make this more dynamic.
- There is a bug in the scaife-skeleton CSS such that if a skeleton is rendered with just a main widget (ie without left or right widgets) then the main widgets styling will not be correct.
- I've rendered a dummy widget on the view to get around this for now.
- The issue seems to stem from [this block of CSS](https://github.com/scaife-viewer/scaife-skeleton/blob/ff07f2fee7e82d552ff3a60bc726ea62a800f675/src/skeleton/sidebar/SidebarWidget.vue#L55), which does seem quite complex and might benefit from a rewrite to separate concerns, if at all possible. I'm adding a bug ticket to the board to this effect. 

### Related PR

- https://github.com/scaife-viewer/sv-mini/pull/8

<img width="2672" alt="Screenshot 2020-02-13 00 22 39" src="https://user-images.githubusercontent.com/1431010/74387180-279c3c00-4df8-11ea-9329-ba3b058b1b74.png">
<img width="2672" alt="Screenshot 2020-02-13 00 22 55" src="https://user-images.githubusercontent.com/1431010/74387184-2b2fc300-4df8-11ea-81cc-2cef5c078b33.png">
<img width="2672" alt="Screenshot 2020-02-13 00 18 16" src="https://user-images.githubusercontent.com/1431010/74387185-2cf98680-4df8-11ea-9767-0e9afcae60b5.png">
