### PR TITLE
Configure a default TOC for a given Version

### DIFF
--- a/src/endpoints/plugin.js
+++ b/src/endpoints/plugin.js
@@ -1,4 +1,5 @@
 const defaultEndpoints = {
+  // 'https://mini-stack-a-feature-se-j47yu0.herokuapp.com';
   tocEndpoint: 'https://sv-mini-atlas.scaife-viewer.org/graphql/',
 };
 

--- a/src/endpoints/plugin.js
+++ b/src/endpoints/plugin.js
@@ -1,6 +1,5 @@
 const defaultEndpoints = {
-  // 'https://mini-stack-a-feature-se-j47yu0.herokuapp.com';
-  tocEndpoint: 'https://sv-mini-atlas.scaife-viewer.org/graphql/',
+  tocEndpoint: 'https://sv-mini-atlas.scaife-viewer.org',
 };
 
 const install = (Vue, options) => {

--- a/src/endpoints/plugin.js
+++ b/src/endpoints/plugin.js
@@ -1,0 +1,27 @@
+const defaultEndpoints = {
+  tocEndpoint: 'https://sv-mini-atlas.scaife-viewer.org/graphql/',
+};
+
+const install = (Vue, options) => {
+  if (install.installed) return;
+  install.installed = true;
+
+  const overriddenEndpoints = options.widgetEndpoints || {};
+  const configuredEndpoints = {
+    ...defaultEndpoints,
+    ...overriddenEndpoints,
+  };
+  // eslint-disable-next-line no-param-reassign
+  Vue.prototype.$scaife = Vue.prototype.$scaife || {};
+
+  // eslint-disable-next-line no-param-reassign
+  Vue.prototype.$scaife = {
+    ...Vue.prototype.$scaife,
+    endpoints: configuredEndpoints,
+  };
+};
+
+const EndpointsPlugin = {
+  install,
+};
+export default EndpointsPlugin;

--- a/src/index.js
+++ b/src/index.js
@@ -32,3 +32,6 @@ export { default as scaifeWidgets } from '@/store';
 // utils
 export { default as URN } from '@/utils/URN';
 export default WIDGETS_NS;
+
+// endpoints
+export { default as EndpointsPlugin } from '@/endpoints/plugin';

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,6 +6,10 @@ import { WIDGETS_NS } from '@/store/constants';
 const state = {
   readerTextSize: 'md',
   readerTextWidth: 'normal',
+  // TODO: Determine if there is a better way to override this
+  tocEndpoint:
+    process.env.VUE_APP_TOC_ENDPOINT ||
+    'https://mini-stack-a-feature-se-j47yu0.herokuapp.com',
 };
 
 export default {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,10 +6,6 @@ import { WIDGETS_NS } from '@/store/constants';
 const state = {
   readerTextSize: 'md',
   readerTextWidth: 'normal',
-  // TODO: Determine if there is a better way to override this
-  tocEndpoint:
-    process.env.VUE_APP_TOC_ENDPOINT ||
-    'https://mini-stack-a-feature-se-j47yu0.herokuapp.com',
 };
 
 export default {

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -36,7 +36,10 @@
           : this.rootTocUrn;
       },
       endpoint() {
-        return 'http://localhost:8000';
+        return (
+          process.env.VUE_APP_TOC_ENDPOINT ||
+          'https://mini-stack-a-feature-se-j47yu0.herokuapp.com'
+        );
       },
       rootTocUrn() {
         return 'urn:cite:scaife-viewer:toc.demo-root';

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -36,10 +36,7 @@
           : this.rootTocUrn;
       },
       endpoint() {
-        return (
-          process.env.VUE_APP_TOC_ENDPOINT ||
-          'https://mini-stack-a-feature-se-j47yu0.herokuapp.com'
-        );
+        return this.$store.state[`${WIDGETS_NS}`].tocEndpoint;
       },
       rootTocUrn() {
         return 'urn:cite:scaife-viewer:toc.demo-root';

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -36,7 +36,7 @@
           : this.rootTocUrn;
       },
       endpoint() {
-        return this.$store.state[`${WIDGETS_NS}`].tocEndpoint;
+        return this.$scaife.endpoints.tocEndpoint;
       },
       rootTocUrn() {
         return 'urn:cite:scaife-viewer:toc.demo-root';

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -6,6 +6,7 @@
 
 <script>
   import TOC from '@/components/TOC.vue';
+  import { WIDGETS_NS } from '@/store/constants';
 
   export default {
     name: 'TOCWidget',
@@ -18,6 +19,7 @@
     },
     watch: {
       $route: 'fetchData',
+      defaultTocUrn: 'fetchData',
     },
     data() {
       return {
@@ -25,21 +27,31 @@
       };
     },
     computed: {
-      endpoint() {
-        return 'https://mini-stack-a-feature-se-j47yu0.herokuapp.com';
+      metadata() {
+        return this.$store.getters[`${WIDGETS_NS}/metadata`];
       },
-      rootToc() {
-        return `${this.endpoint}/tocs/toc.demo-root.json`;
+      defaultTocUrn() {
+        return this.metadata && this.metadata.defaultTocUrn
+          ? this.metadata.defaultTocUrn
+          : this.rootTocUrn;
+      },
+      endpoint() {
+        return 'http://localhost:8000';
+      },
+      rootTocUrn() {
+        return 'urn:cite:scaife-viewer:toc.demo-root';
+      },
+      rootTocUrl() {
+        return this.getTocUrl(this.rootTocUrn);
       },
       url() {
         if (this.$route.name === 'reader') {
-          // TODO: Some kind of version specific TOC lookup logic goes here.
-          return `${this.endpoint}/tocs/toc.oaf-1.json`;
+          return this.getTocUrl(this.defaultTocUrn);
         }
-        const urn = this.$route.query ? this.$route.query.urn : false;
-        return urn
-          ? `${this.endpoint}/tocs/${urn.split(':').slice(-1)}.json`
-          : this.rootToc;
+        const urn = this.$route.query.urn
+          ? this.$route.query.urn
+          : this.rootTocUrn;
+        return this.getTocUrl(urn);
       },
     },
     methods: {
@@ -53,6 +65,9 @@
             // eslint-disable-next-line no-console
             console.error(error);
           });
+      },
+      getTocUrl(tocUrn) {
+        return `${this.endpoint}/tocs/${tocUrn.split(':').slice(-1)}.json`;
       },
     },
   };

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -44,7 +44,7 @@ describe('TOCWidget.vue', () => {
     });
     wrapper.setData({ toc });
 
-    expect(fetchData).toHaveBeenCalledWith(`${endpoint}/tocs/toc.oaf-1.json`);
+    expect(fetchData).toHaveBeenCalledWith(`${endpoint}/tocs/toc.demo-root.json`);
 
     const container = wrapper.find('div');
     expect(container.classes()).toContain('toc-widget');
@@ -53,7 +53,7 @@ describe('TOCWidget.vue', () => {
 
   it('Renders the root TOC when no query is given', () => {
     const fetchData = jest.fn();
-    const $route = { name: 'tocs' };
+    const $route = { name: 'tocs', query: { urn: '' } };
 
     const store = new Vuex.Store({
       modules: {

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -30,6 +30,7 @@ describe('TOCWidget.vue', () => {
   it('Parses a URL, passes props and renders a TOC on the reader.', () => {
     const fetchData = jest.fn();
     const $route = { name: 'reader' };
+    const $scaife = { endpoints: { tocEndpoint: endpoint } };
 
     const store = new Vuex.Store({
       modules: {
@@ -40,11 +41,13 @@ describe('TOCWidget.vue', () => {
       store,
       localVue,
       methods: { fetchData },
-      mocks: { $route },
+      mocks: { $route, $scaife },
     });
     wrapper.setData({ toc });
 
-    expect(fetchData).toHaveBeenCalledWith(`${endpoint}/tocs/toc.demo-root.json`);
+    expect(fetchData).toHaveBeenCalledWith(
+      `${endpoint}/tocs/toc.demo-root.json`,
+    );
 
     const container = wrapper.find('div');
     expect(container.classes()).toContain('toc-widget');
@@ -54,6 +57,7 @@ describe('TOCWidget.vue', () => {
   it('Renders the root TOC when no query is given', () => {
     const fetchData = jest.fn();
     const $route = { name: 'tocs', query: { urn: '' } };
+    const $scaife = { endpoints: { tocEndpoint: endpoint } };
 
     const store = new Vuex.Store({
       modules: {
@@ -64,7 +68,7 @@ describe('TOCWidget.vue', () => {
       store,
       localVue,
       methods: { fetchData },
-      mocks: { $route },
+      mocks: { $route, $scaife },
     });
     wrapper.setData({ toc });
 
@@ -83,6 +87,7 @@ describe('TOCWidget.vue', () => {
       name: 'tocs',
       query: { urn: 'urn:cite:scaife-viewer:toc.oaf-1' },
     };
+    const $scaife = { endpoints: { tocEndpoint: endpoint } };
 
     const store = new Vuex.Store({
       modules: {
@@ -93,7 +98,7 @@ describe('TOCWidget.vue', () => {
       store,
       localVue,
       methods: { fetchData },
-      mocks: { $route },
+      mocks: { $route, $scaife },
     });
     wrapper.setData({ toc });
 


### PR DESCRIPTION
- Retrieve a default TOC if `defaultTocUrn ` has been defined for a Version (ATLAS PR: https://github.com/scaife-viewer/sv-mini-atlas/pull/6)
- Show's the root TOC by default 
- Configure the TOC endpoint in the store (so it can be overridden in a particular project, or in this case, a particular branch of a project as deployed to Netlify)