### PR TITLE
TOC Lookahead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10674,6 +10674,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "core-js": "^3.3.2",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
+    "lodash.debounce": "^4.0.8",
     "node-sass": "^4.13.0",
     "query-string": "^6.11.0",
     "vue": "^2.6.10"

--- a/src/components/Lookahead.vue
+++ b/src/components/Lookahead.vue
@@ -16,7 +16,7 @@
   import debounce from 'lodash.debounce';
 
   export default {
-    props: ['placeholder', 'lenses', 'data'],
+    props: ['placeholder', 'reducer', 'data'],
     data() {
       return {
         query: '',
@@ -31,30 +31,13 @@
         this.query = '';
       },
       updateData() {
-        this.results = this.filter(this.data);
+        this.results = this.reducer(this.data, this.query);
         this.$emit('filter-data', this.results);
       },
       onInput() {
         debounce(e => {
           this.query = e.target.value;
         }, 500);
-      },
-      filter(data) {
-        return {
-          ...data,
-          items: this.reduce(data.items),
-        };
-      },
-      reduce(items) {
-        return items.filter(item =>
-          Object.values(this.lenses)
-            .map(getter =>
-              getter(item)
-                .toLowerCase()
-                .includes(this.query.toLowerCase()),
-            )
-            .some(Boolean),
-        );
       },
     },
   };

--- a/src/components/Lookahead.vue
+++ b/src/components/Lookahead.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="form-group">
+    <div class="input-group u-flex">
+      <input
+        type="search"
+        class="form-control"
+        v-model="query"
+        :placeholder="placeholder"
+        @input="onInput"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+  import debounce from 'lodash.debounce';
+
+  export default {
+    props: ['placeholder', 'lenses', 'data'],
+    data() {
+      return {
+        query: '',
+        results: null,
+      };
+    },
+    watch: {
+      query: 'updateData',
+    },
+    methods: {
+      onClear() {
+        this.query = '';
+      },
+      updateData() {
+        this.results = this.filter(this.data);
+        this.$emit('filter-data', this.results);
+      },
+      onInput() {
+        debounce(e => {
+          this.query = e.target.value;
+        }, 500);
+      },
+      filter(data) {
+        return {
+          ...data,
+          items: this.reduce(data.items),
+        };
+      },
+      reduce(items) {
+        return items.filter(item =>
+          Object.values(this.lenses)
+            .map(getter =>
+              getter(item)
+                .toLowerCase()
+                .includes(this.query.toLowerCase()),
+            )
+            .some(Boolean),
+        );
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .form-group {
+    margin-bottom: 0.66em;
+  }
+</style>

--- a/src/components/Lookahead.vue
+++ b/src/components/Lookahead.vue
@@ -27,9 +27,6 @@
       query: 'updateData',
     },
     methods: {
-      onClear() {
-        this.query = '';
-      },
       updateData() {
         this.results = this.reducer(this.data, this.query);
         this.$emit('filter-data', this.results);

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -2,7 +2,7 @@
   <aside class="toc-container u-flex">
     <h3>{{ toc.title }}</h3>
     <p>{{ toc.description }}</p>
-    <ul>
+    <ul v-if="toc.items.length">
       <li class="u-flex" v-for="(item, index) in toc.items" :key="index">
         <span class="ref">{{ index + 1 }}.</span>
         <div class="item u-flex">
@@ -20,6 +20,7 @@
         </div>
       </li>
     </ul>
+    <h4 v-else>No results.</h4>
   </aside>
 </template>
 

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -10,7 +10,7 @@ ul {
   list-style: none;
 }
 
-h3 {
+h3,h4 {
   margin: 0;
 }
 

--- a/src/utils/iconMap.js
+++ b/src/utils/iconMap.js
@@ -11,7 +11,6 @@ import { faSquare } from '@fortawesome/free-solid-svg-icons/faSquare';
 import { faMinusCircle } from '@fortawesome/free-solid-svg-icons/faMinusCircle';
 import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand';
 import { faCompress } from '@fortawesome/free-solid-svg-icons/faCompress';
-import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 
 const iconMap = [
   faChevronDown,
@@ -26,7 +25,6 @@ const iconMap = [
   faMinusCircle,
   faExpand,
   faCompress,
-  faTimes,
 ].reduce((map, obj) => {
   map[obj.iconName] = obj;
   return map;

--- a/src/utils/iconMap.js
+++ b/src/utils/iconMap.js
@@ -11,6 +11,7 @@ import { faSquare } from '@fortawesome/free-solid-svg-icons/faSquare';
 import { faMinusCircle } from '@fortawesome/free-solid-svg-icons/faMinusCircle';
 import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand';
 import { faCompress } from '@fortawesome/free-solid-svg-icons/faCompress';
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 
 const iconMap = [
   faChevronDown,
@@ -25,6 +26,7 @@ const iconMap = [
   faMinusCircle,
   faExpand,
   faCompress,
+  faTimes,
 ].reduce((map, obj) => {
   map[obj.iconName] = obj;
   return map;

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -1,0 +1,17 @@
+const tocReducer = (data, query) => {
+  const lenses = { getTitle: obj => obj.title, getUri: obj => obj.uri };
+  return {
+    ...data,
+    items: data.items.filter(obj =>
+      Object.values(lenses)
+        .map(lens =>
+          lens(obj)
+            .toLowerCase()
+            .includes(query.toLowerCase()),
+        )
+        .some(Boolean),
+    ),
+  };
+};
+
+export default { tocReducer };

--- a/src/widgets/NewAlexandriaWidget.vue
+++ b/src/widgets/NewAlexandriaWidget.vue
@@ -73,7 +73,8 @@
             this.comments = data.data.commentsOn;
           })
           .catch(error => {
-            throw new Error(error.message);
+            // eslint-disable-next-line no-console
+            console.log(error.message);
           });
       },
     },

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -1,16 +1,26 @@
 <template>
   <div class="toc-widget u-widget u-flex">
-    <TOC :toc="toc" v-if="toc" />
+    <Lookahead
+      :placeholder="placeholder"
+      :lenses="lenses"
+      :data="toc"
+      @filter-data="filterData"
+    />
+    <TOC :toc="filtered || toc" v-if="toc" />
   </div>
 </template>
 
 <script>
+  import Lookahead from '@/components/Lookahead.vue';
   import TOC from '@/components/TOC.vue';
   import { WIDGETS_NS } from '@/store/constants';
 
   export default {
     name: 'TOCWidget',
-    components: { TOC },
+    components: {
+      Lookahead,
+      TOC,
+    },
     scaifeConfig: {
       displayName: 'Table of Contents',
     },
@@ -24,6 +34,7 @@
     data() {
       return {
         toc: null,
+        filtered: null,
       };
     },
     computed: {
@@ -34,6 +45,12 @@
         return this.metadata && this.metadata.defaultTocUrn
           ? this.metadata.defaultTocUrn
           : this.rootTocUrn;
+      },
+      placeholder() {
+        return 'Search this table of contents...';
+      },
+      lenses() {
+        return { getTitle: item => item.title, getUri: item => item.uri };
       },
       endpoint() {
         return this.$scaife.endpoints.tocEndpoint;
@@ -55,6 +72,9 @@
       },
     },
     methods: {
+      filterData(data) {
+        this.filtered = data;
+      },
       fetchData() {
         fetch(this.url)
           .then(response => response.json())
@@ -74,6 +94,7 @@
 
 <style lang="scss" scoped>
   .toc-widget {
+    flex-direction: column;
     justify-content: flex-start;
     width: 100%;
   }

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="toc-widget u-widget u-flex">
+  <div class="toc-widget u-widget u-flex" v-if="toc">
     <Lookahead
       :placeholder="placeholder"
       :reducer="reducer"
       :data="toc"
       @filter-data="filterData"
     />
-    <TOC :toc="filtered || toc" v-if="toc" />
+    <TOC :toc="filtered || toc" />
   </div>
 </template>
 

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -2,7 +2,7 @@
   <div class="toc-widget u-widget u-flex">
     <Lookahead
       :placeholder="placeholder"
-      :lenses="lenses"
+      :reducer="reducer"
       :data="toc"
       @filter-data="filterData"
     />
@@ -14,6 +14,7 @@
   import Lookahead from '@/components/Lookahead.vue';
   import TOC from '@/components/TOC.vue';
   import { WIDGETS_NS } from '@/store/constants';
+  import reducers from '@/utils/reducers';
 
   export default {
     name: 'TOCWidget',
@@ -41,19 +42,19 @@
       metadata() {
         return this.$store.getters[`${WIDGETS_NS}/metadata`];
       },
-      defaultTocUrn() {
-        return this.metadata && this.metadata.defaultTocUrn
-          ? this.metadata.defaultTocUrn
-          : this.rootTocUrn;
+      reducer() {
+        return reducers.tocReducer;
       },
       placeholder() {
         return 'Search this table of contents...';
       },
-      lenses() {
-        return { getTitle: item => item.title, getUri: item => item.uri };
-      },
       endpoint() {
         return this.$scaife.endpoints.tocEndpoint;
+      },
+      defaultTocUrn() {
+        return this.metadata && this.metadata.defaultTocUrn
+          ? this.metadata.defaultTocUrn
+          : this.rootTocUrn;
       },
       rootTocUrn() {
         return 'urn:cite:scaife-viewer:toc.demo-root';

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -83,7 +83,8 @@
             this.toc = data;
           })
           .catch(error => {
-            throw new Error(error.message);
+            // eslint-disable-next-line no-console
+            console.log(error.message);
           });
       },
       getTocUrl(tocUrn) {

--- a/src/widgets/WordListWidget.vue
+++ b/src/widgets/WordListWidget.vue
@@ -63,7 +63,8 @@
             }));
           })
           .catch(error => {
-            throw new Error(error.message);
+            // eslint-disable-next-line no-console
+            console.log(error.message);
           });
       },
     },

--- a/tests/components/Lookahead.spec.js
+++ b/tests/components/Lookahead.spec.js
@@ -1,0 +1,107 @@
+/* global describe, expect, it  */
+import { shallowMount, RouterLinkStub } from '@vue/test-utils';
+
+import Lookahead from '@/components/Lookahead.vue';
+
+const placeholder = 'Some placeholder';
+
+const data = {
+  '@id': 'urn:cite:scaife-viewer:toc.1',
+  title: 'Some Table of Contents',
+  items: [
+    {
+      title: 'Foo',
+      uri: 'urn:cts:1:1.1.1:1-2',
+      nested: {
+        field: 'Some value',
+      },
+    },
+    {
+      title: 'Bar',
+      uri: 'urn:cts:1:1.1.2:1-2',
+      nested: {
+        field: 'Another value',
+      },
+    },
+  ],
+};
+
+const lenses = {
+  getTitle: item => item.title,
+  getField: item => item.nested.field,
+};
+
+describe('Lookahead.vue', () => {
+  it('Renders an empty input field.', () => {
+    const wrapper = shallowMount(Lookahead, {
+      propsData: { placeholder, lenses, data },
+    });
+
+    const input = wrapper.find('input');
+    expect(input.exists()).toBeTruthy();
+    expect(input.element.placeholder).toEqual('Some placeholder');
+    expect(input.element.value).toBe('');
+    expect(wrapper.vm.query).toBe('');
+    expect(wrapper.vm.results).toBe(null);
+  });
+
+  it('Filters data by term ignoring case.', async () => {
+    const wrapper = shallowMount(Lookahead, {
+      propsData: { placeholder, lenses, data },
+    });
+
+    expect(wrapper.vm.query).toBe('');
+    expect(wrapper.vm.results).toBe(null);
+
+    const input = wrapper.find('input');
+    input.element.value = 'foo';
+    input.trigger('input');
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.query).toBe('foo');
+    expect(wrapper.vm.results.items.length).toBe(1);
+    expect(wrapper.vm.results).toEqual({
+      '@id': 'urn:cite:scaife-viewer:toc.1',
+      title: 'Some Table of Contents',
+      items: [
+        {
+          title: 'Foo',
+          uri: 'urn:cts:1:1.1.1:1-2',
+          nested: { field: 'Some value' },
+        },
+      ],
+    });
+  });
+
+  it('Filters data across multiple fields.', async () => {
+    const wrapper = shallowMount(Lookahead, {
+      propsData: { placeholder, lenses, data },
+    });
+
+    expect(wrapper.vm.query).toBe('');
+    expect(wrapper.vm.results).toBe(null);
+
+    const input = wrapper.find('input');
+    input.element.value = 'another';
+    input.trigger('input');
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.query).toBe('another');
+    expect(wrapper.vm.results.items.length).toBe(1);
+    expect(wrapper.vm.results).toEqual({
+      '@id': 'urn:cite:scaife-viewer:toc.1',
+      title: 'Some Table of Contents',
+      items: [
+        {
+          title: 'Bar',
+          uri: 'urn:cts:1:1.1.2:1-2',
+          nested: {
+            field: 'Another value',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/tests/components/Lookahead.spec.js
+++ b/tests/components/Lookahead.spec.js
@@ -1,107 +1,96 @@
 /* global describe, expect, it  */
-import { shallowMount, RouterLinkStub } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 
 import Lookahead from '@/components/Lookahead.vue';
+import reducers from '@/utils/reducers';
 
 const placeholder = 'Some placeholder';
 
-const data = {
-  '@id': 'urn:cite:scaife-viewer:toc.1',
-  title: 'Some Table of Contents',
-  items: [
-    {
-      title: 'Foo',
-      uri: 'urn:cts:1:1.1.1:1-2',
-      nested: {
-        field: 'Some value',
-      },
-    },
-    {
-      title: 'Bar',
-      uri: 'urn:cts:1:1.1.2:1-2',
-      nested: {
-        field: 'Another value',
-      },
-    },
-  ],
-};
-
-const lenses = {
-  getTitle: item => item.title,
-  getField: item => item.nested.field,
-};
-
 describe('Lookahead.vue', () => {
-  it('Renders an empty input field.', () => {
-    const wrapper = shallowMount(Lookahead, {
-      propsData: { placeholder, lenses, data },
-    });
-
-    const input = wrapper.find('input');
-    expect(input.exists()).toBeTruthy();
-    expect(input.element.placeholder).toEqual('Some placeholder');
-    expect(input.element.value).toBe('');
-    expect(wrapper.vm.query).toBe('');
-    expect(wrapper.vm.results).toBe(null);
-  });
-
-  it('Filters data by term ignoring case.', async () => {
-    const wrapper = shallowMount(Lookahead, {
-      propsData: { placeholder, lenses, data },
-    });
-
-    expect(wrapper.vm.query).toBe('');
-    expect(wrapper.vm.results).toBe(null);
-
-    const input = wrapper.find('input');
-    input.element.value = 'foo';
-    input.trigger('input');
-
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.vm.query).toBe('foo');
-    expect(wrapper.vm.results.items.length).toBe(1);
-    expect(wrapper.vm.results).toEqual({
+  describe('Composing with TOC logic', () => {
+    const reducer = reducers.tocReducer;
+    const data = {
       '@id': 'urn:cite:scaife-viewer:toc.1',
       title: 'Some Table of Contents',
       items: [
         {
           title: 'Foo',
           uri: 'urn:cts:1:1.1.1:1-2',
-          nested: { field: 'Some value' },
         },
-      ],
-    });
-  });
-
-  it('Filters data across multiple fields.', async () => {
-    const wrapper = shallowMount(Lookahead, {
-      propsData: { placeholder, lenses, data },
-    });
-
-    expect(wrapper.vm.query).toBe('');
-    expect(wrapper.vm.results).toBe(null);
-
-    const input = wrapper.find('input');
-    input.element.value = 'another';
-    input.trigger('input');
-
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.vm.query).toBe('another');
-    expect(wrapper.vm.results.items.length).toBe(1);
-    expect(wrapper.vm.results).toEqual({
-      '@id': 'urn:cite:scaife-viewer:toc.1',
-      title: 'Some Table of Contents',
-      items: [
         {
           title: 'Bar',
           uri: 'urn:cts:1:1.1.2:1-2',
-          nested: {
-            field: 'Another value',
-          },
         },
       ],
+    };
+
+    it('Renders an empty input field.', () => {
+      const wrapper = shallowMount(Lookahead, {
+        propsData: { placeholder, reducer, data },
+      });
+
+      const input = wrapper.find('input');
+      expect(input.exists()).toBeTruthy();
+      expect(input.element.placeholder).toEqual('Some placeholder');
+      expect(input.element.value).toBe('');
+      expect(wrapper.vm.query).toBe('');
+      expect(wrapper.vm.results).toBe(null);
+    });
+
+    it('Filters data by term ignoring case.', async () => {
+      const wrapper = shallowMount(Lookahead, {
+        propsData: { placeholder, reducer, data },
+      });
+
+      expect(wrapper.vm.query).toBe('');
+      expect(wrapper.vm.results).toBe(null);
+
+      const input = wrapper.find('input');
+      input.element.value = 'foo';
+      input.trigger('input');
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.query).toBe('foo');
+      expect(wrapper.vm.results.items.length).toBe(1);
+      expect(wrapper.vm.results).toEqual({
+        '@id': 'urn:cite:scaife-viewer:toc.1',
+        title: 'Some Table of Contents',
+        items: [
+          {
+            title: 'Foo',
+            uri: 'urn:cts:1:1.1.1:1-2',
+          },
+        ],
+      });
+    });
+
+    it('Filters data across multiple fields.', async () => {
+      const wrapper = shallowMount(Lookahead, {
+        propsData: { placeholder, reducer, data },
+      });
+
+      expect(wrapper.vm.query).toBe('');
+      expect(wrapper.vm.results).toBe(null);
+
+      const input = wrapper.find('input');
+      input.element.value = '2:1-2';
+      input.trigger('input');
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.query).toBe('2:1-2');
+      expect(wrapper.vm.results.items.length).toBe(1);
+      expect(wrapper.vm.results).toEqual({
+        '@id': 'urn:cite:scaife-viewer:toc.1',
+        title: 'Some Table of Contents',
+        items: [
+          {
+            title: 'Bar',
+            uri: 'urn:cts:1:1.1.2:1-2',
+          },
+        ],
+      });
     });
   });
 });

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -48,9 +48,8 @@ describe('TOCWidget.vue', () => {
 
     expect(global.fetch).toBeCalledWith(`${endpoint}/tocs/toc.demo-root.json`);
 
-    const container = wrapper.find('div');
-    expect(container.classes()).toContain('toc-widget');
-    expect(wrapper.find(TOC).exists()).toBeFalsy();
+    const container = wrapper.find('div.toc-widget');
+    expect(container.exists()).toBeFalsy();
   });
 
   it('Parses a URL, fetches data and renders a reader TOC.', async () => {

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -83,7 +83,6 @@ describe('TOCWidget.vue', () => {
   it('Renders a lookahead on the reader.', () => {
     const fetchData = jest.fn();
     const $route = { name: 'tocs' };
-    const lenses = { getField: item => item.field };
 
     const store = new Vuex.Store({
       modules: {
@@ -94,11 +93,6 @@ describe('TOCWidget.vue', () => {
       store,
       localVue,
       methods: { fetchData },
-      computed: {
-        lenses() {
-          return lenses;
-        },
-      },
       mocks: { $route },
     });
     wrapper.setData({ toc });
@@ -106,9 +100,9 @@ describe('TOCWidget.vue', () => {
     const lookahead = wrapper.find(Lookahead);
     expect(lookahead.exists()).toBeTruthy();
     expect(lookahead.props()).toEqual({
-      lenses,
       data: toc,
       placeholder: 'Search this table of contents...',
+      reducer: wrapper.vm.reducer,
     });
   });
 

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -5,6 +5,7 @@ import Vuex from 'vuex';
 import scaifeWidgets from '@/store';
 import TOCWidget from '@/widgets/TOCWidget.vue';
 import TOC from '@/components/TOC.vue';
+import Lookahead from '@/components/Lookahead.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -77,6 +78,38 @@ describe('TOCWidget.vue', () => {
     const container = wrapper.find('div');
     expect(container.classes()).toContain('toc-widget');
     expect(wrapper.find(TOC).props()).toEqual({ toc });
+  });
+
+  it('Renders a lookahead on the reader.', () => {
+    const fetchData = jest.fn();
+    const $route = { name: 'tocs' };
+    const lenses = { getField: item => item.field };
+
+    const store = new Vuex.Store({
+      modules: {
+        [scaifeWidgets.namespace]: scaifeWidgets.store,
+      },
+    });
+    const wrapper = shallowMount(TOCWidget, {
+      store,
+      localVue,
+      methods: { fetchData },
+      computed: {
+        lenses() {
+          return lenses;
+        },
+      },
+      mocks: { $route },
+    });
+    wrapper.setData({ toc });
+
+    const lookahead = wrapper.find(Lookahead);
+    expect(lookahead.exists()).toBeTruthy();
+    expect(lookahead.props()).toEqual({
+      lenses,
+      data: toc,
+      placeholder: 'Search this table of contents...',
+    });
   });
 
   it('Renders the root TOC when no query is given', async () => {


### PR DESCRIPTION
https://trello.com/c/uFX2amOj/59-as-a-user-i-want-to-be-able-to-filter-down-entries-in-a-toc

Adds modular lookahead component and logic. Data handling and filtering labour is defined and executed outside of the lookahead, being passed into the component itself as props by the relevant widget's 'container' component.

<img width="2672" alt="Screenshot 2020-02-26 17 43 35" src="https://user-images.githubusercontent.com/1431010/75366879-b791b980-58bf-11ea-9f88-7f190e2c73b8.png">