### PR TITLE
TOC Navigation

### DIFF
--- a/_example/sample/src/App.vue
+++ b/_example/sample/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <HelloWorld msg="hi!"></HelloWorld>
-    <Icon name="chevron-left" fixed-width />
+    <Icon name="chevron-left" />
     <Metadata workTitle="test" />
     <Paginator :urn="previous" direction="left" />
     <TextSize :value="textSize" @input="changeTextSize" size="xs" />{{ " " }}

--- a/src/components/Lookahead.vue
+++ b/src/components/Lookahead.vue
@@ -21,15 +21,25 @@
       return {
         query: '',
         results: null,
+        reduce: true,
       };
     },
     watch: {
+      $route: 'resetQuery',
       query: 'updateData',
     },
     methods: {
       updateData() {
-        this.results = this.reducer(this.data, this.query);
-        this.$emit('filter-data', this.results);
+        // Prevents intermediate flash reload of stale data on query reset.
+        if (this.reduce) {
+          this.results = this.reducer(this.data, this.query);
+          this.$emit('filter-data', this.results);
+        }
+        this.reduce = true;
+      },
+      resetQuery() {
+        this.query = '';
+        this.reduce = false;
       },
       onInput() {
         debounce(e => {
@@ -39,9 +49,3 @@
     },
   };
 </script>
-
-<style lang="scss" scoped>
-  .form-group {
-    margin-bottom: 0.66em;
-  }
-</style>

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -3,7 +3,7 @@
     <div class="node-container u-flex">
       <template v-if="hasChildren">
         <span class="open-toggle" @click.prevent="toggle">
-          <Icon :name="icon" class="fa-xs" fixed-width />
+          <Icon :name="icon" class="fa-xs" />
         </span>
       </template>
 

--- a/src/components/Paginator.vue
+++ b/src/components/Paginator.vue
@@ -5,7 +5,7 @@
       :key="urn.absolute"
       :to="{ path: 'reader', query: { urn: `${urn.absolute}` } }"
     >
-      <Icon :name="icon" fixed-width />
+      <Icon :name="icon" />
     </router-link>
   </nav>
 </template>

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -1,11 +1,11 @@
 <template>
-  <aside class="toc-container u-flex">
+  <aside class="toc-container">
     <h3>{{ toc.title }}</h3>
-    <p>{{ toc.description }}</p>
-    <ul v-if="toc.items.length">
-      <li class="u-flex" v-for="(item, index) in toc.items" :key="index">
-        <span class="ref">{{ index + 1 }}.</span>
-        <div class="item u-flex">
+    <p class="u-legend">{{ toc.description }}</p>
+    <div class="u-grid toc-grid" v-if="toc.items.length">
+      <template v-for="(item, index) in toc.items">
+        <span :key="`index-${index}`" class="ref">{{ index + 1 }}.</span>
+        <div :key="`item-${index}`" class="item u-flex">
           <router-link :to="getPayload(item.uri)">
             {{ item.title }}
           </router-link>
@@ -13,8 +13,8 @@
             <tt>{{ item.uri }}</tt>
           </span>
         </div>
-      </li>
-    </ul>
+      </template>
+    </div>
     <h4 v-else>No results.</h4>
   </aside>
 </template>
@@ -50,32 +50,24 @@
     flex-direction: column;
     width: 100%;
   }
+  .toc-grid {
+    align-items: baseline;
+    grid-template-columns: auto 9.25fr;
+    grid-column-gap: 1em;
+    > * {
+      margin-bottom: 0.33em;
+    }
+  }
   p {
     margin: 0.66em 0;
   }
-  ul {
-    margin: 0;
-    padding: 0;
-    width: 100%;
-  }
-  li {
-    align-items: baseline;
-    margin-bottom: 0.33em;
-    span.ref {
-      font-size: 10pt;
-      color: #69c;
-      font-family: 'Noto Sans';
-      text-align: right;
-      min-width: 2em;
-    }
+  span.ref {
+    font-size: 10pt;
+    color: #69c;
+    font-family: 'Noto Sans';
+    text-align: left;
   }
   .item {
-    flex-wrap: wrap;
-    width: 100%;
-    > * {
-      margin-left: 1em;
-      flex-shrink: 0;
-      flex: 1 0 48%;
-    }
+    flex-direction: column;
   }
 </style>

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -9,7 +9,7 @@
           <router-link :to="getPayload(item.uri)">
             {{ item.title }}
           </router-link>
-          <span>
+          <span v-if="showURNs">
             <tt>{{ item.uri }}</tt>
           </span>
         </div>
@@ -22,7 +22,7 @@
 <script>
   export default {
     name: 'TOC',
-    props: ['toc', 'context', 'passage'],
+    props: ['toc', 'context', 'passage', 'showURNs'],
     methods: {
       isCiteUrn(urn) {
         return urn.startsWith('urn:cite:');

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -6,12 +6,7 @@
       <li class="u-flex" v-for="(item, index) in toc.items" :key="index">
         <span class="ref">{{ index + 1 }}.</span>
         <div class="item u-flex">
-          <router-link
-            :to="{
-              path: isCiteUrn(item.uri) ? 'tocs' : 'reader',
-              query: { urn: item.uri },
-            }"
-          >
+          <router-link :to="getPayload(item.uri)">
             {{ item.title }}
           </router-link>
           <span>
@@ -27,10 +22,19 @@
 <script>
   export default {
     name: 'TOC',
-    props: ['toc'],
+    props: ['toc', 'context', 'passage'],
     methods: {
       isCiteUrn(urn) {
         return urn.startsWith('urn:cite:');
+      },
+      getPayload(urn) {
+        if (this.isCiteUrn(urn)) {
+          const passage = this.passage.absolute;
+          return this.context === 'tocs'
+            ? { path: 'tocs', query: { urn } }
+            : { path: 'reader', query: { urn: passage, toc: urn } };
+        }
+        return { path: 'reader', query: { urn } };
       },
     },
   };

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -29,12 +29,16 @@
       },
       getPayload(urn) {
         if (this.isCiteUrn(urn)) {
-          const passage = this.passage.absolute;
           return this.context === 'tocs'
             ? { path: 'tocs', query: { urn } }
-            : { path: 'reader', query: { urn: passage, toc: urn } };
+            : {
+              path: 'reader',
+              query: { urn: this.passage.absolute, toc: urn },
+            };
         }
-        return { path: 'reader', query: { urn } };
+        return this.$route.query.toc
+          ? { path: 'reader', query: { urn, toc: this.$route.query.toc } }
+          : { path: 'reader', query: { urn } };
       },
     },
   };

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -53,13 +53,13 @@ svg[disabled] {
   display: flex;
 }
 
+.u-grid {
+  display: grid;
+}
+
 .u-widget {
   margin: 0 2em;
   overflow-y: auto;
-}
-
-.main-layout .u-widget {
-  max-height: none;
 }
 
 .u-legend {

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -14,6 +14,12 @@ h3,h4 {
   margin: 0;
 }
 
+svg[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .text-xs {
   font-size: 12px;
 }

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -55,7 +55,6 @@ svg[disabled] {
 
 .u-widget {
   margin: 0 2em;
-  max-height: 17em;
   overflow-y: auto;
 }
 

--- a/src/utils/iconMap.js
+++ b/src/utils/iconMap.js
@@ -11,6 +11,7 @@ import { faSquare } from '@fortawesome/free-solid-svg-icons/faSquare';
 import { faMinusCircle } from '@fortawesome/free-solid-svg-icons/faMinusCircle';
 import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand';
 import { faCompress } from '@fortawesome/free-solid-svg-icons/faCompress';
+import { faHome } from '@fortawesome/free-solid-svg-icons/faHome';
 
 const iconMap = [
   faChevronDown,
@@ -25,6 +26,7 @@ const iconMap = [
   faMinusCircle,
   faExpand,
   faCompress,
+  faHome,
 ].reduce((map, obj) => {
   map[obj.iconName] = obj;
   return map;

--- a/src/utils/iconMap.js
+++ b/src/utils/iconMap.js
@@ -12,6 +12,8 @@ import { faMinusCircle } from '@fortawesome/free-solid-svg-icons/faMinusCircle';
 import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand';
 import { faCompress } from '@fortawesome/free-solid-svg-icons/faCompress';
 import { faHome } from '@fortawesome/free-solid-svg-icons/faHome';
+import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
+import { faEyeSlash } from '@fortawesome/free-solid-svg-icons/faEyeSlash';
 
 const iconMap = [
   faChevronDown,
@@ -27,6 +29,8 @@ const iconMap = [
   faExpand,
   faCompress,
   faHome,
+  faEye,
+  faEyeSlash,
 ].reduce((map, obj) => {
   map[obj.iconName] = obj;
   return map;

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -1,16 +1,23 @@
 <template>
   <div class="toc-widget u-widget u-flex" v-if="toc">
-    <Lookahead
-      :placeholder="placeholder"
-      :reducer="reducer"
-      :data="toc"
-      @filter-data="filterData"
-    />
+    <div class="lookahead-container u-flex">
+      <Lookahead
+        :placeholder="placeholder"
+        :reducer="reducer"
+        :data="toc"
+        @filter-data="filterData"
+      />
+      <Icon class="root-toc-icon" name="home" v-if="showingRootToc" disabled />
+      <router-link class="root-toc-icon" :to="returnToRootPayload" v-else>
+        <Icon name="home" />
+      </router-link>
+    </div>
     <TOC :toc="filtered || toc" :context="context" :passage="passage" />
   </div>
 </template>
 
 <script>
+  import Icon from '@/components/Icon.vue';
   import Lookahead from '@/components/Lookahead.vue';
   import TOC from '@/components/TOC.vue';
   import { WIDGETS_NS } from '@/store/constants';
@@ -19,6 +26,7 @@
   export default {
     name: 'TOCWidget',
     components: {
+      Icon,
       Lookahead,
       TOC,
     },
@@ -42,14 +50,27 @@
       context() {
         return this.$route.name;
       },
+      placeholder() {
+        return 'Search this table of contents...';
+      },
+      passage() {
+        return this.$store.getters[`${WIDGETS_NS}/passage`];
+      },
       metadata() {
         return this.$store.getters[`${WIDGETS_NS}/metadata`];
       },
       reducer() {
         return reducers.tocReducer;
       },
-      placeholder() {
-        return 'Search this table of contents...';
+      showingRootToc() {
+        return this.context == 'tocs'
+          ? !this.$route.query.urn
+          : !this.$route.query.toc;
+      },
+      returnToRootPayload() {
+        return this.context == 'tocs'
+          ? { path: 'tocs' }
+          : { path: 'reader', query: { urn: this.passage.absolute } };
       },
       endpoint() {
         return this.$scaife.endpoints.tocEndpoint;
@@ -77,9 +98,6 @@
           : this.rootTocUrn;
         return this.getTocUrl(urn);
       },
-      passage() {
-        return this.$store.getters[`${WIDGETS_NS}/passage`];
-      },
     },
     methods: {
       filterData(data) {
@@ -90,6 +108,7 @@
           .then(response => response.json())
           .then(data => {
             this.toc = data;
+            this.filtered = null;
           })
           .catch(error => {
             // eslint-disable-next-line no-console
@@ -108,5 +127,16 @@
     flex-direction: column;
     justify-content: flex-start;
     width: 100%;
+  }
+  .lookahead-container {
+    align-items: center;
+    margin-bottom: 0.66em;
+    .form-group {
+      width: 90%;
+    }
+  }
+  .root-toc-icon {
+    color: black;
+    margin-left: 0.66em;
   }
 </style>

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -6,7 +6,7 @@
       :data="toc"
       @filter-data="filterData"
     />
-    <TOC :toc="filtered || toc" />
+    <TOC :toc="filtered || toc" :context="context" :passage="passage" />
   </div>
 </template>
 
@@ -39,6 +39,9 @@
       };
     },
     computed: {
+      context() {
+        return this.$route.name;
+      },
       metadata() {
         return this.$store.getters[`${WIDGETS_NS}/metadata`];
       },
@@ -63,13 +66,19 @@
         return this.getTocUrl(this.rootTocUrn);
       },
       url() {
-        if (this.$route.name === 'reader') {
+        if (this.$route.query.toc) {
+          return this.getTocUrl(this.$route.query.toc);
+        }
+        if (this.context === 'reader') {
           return this.getTocUrl(this.defaultTocUrn);
         }
         const urn = this.$route.query.urn
           ? this.$route.query.urn
           : this.rootTocUrn;
         return this.getTocUrl(urn);
+      },
+      passage() {
+        return this.$store.getters[`${WIDGETS_NS}/passage`];
       },
     },
     methods: {

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -72,41 +72,41 @@
       reducer() {
         return reducers.tocReducer;
       },
-      showingRootToc() {
-        return this.context == 'tocs'
-          ? !this.$route.query.urn
-          : !this.$route.query.toc;
+      endpoint() {
+        return this.$scaife.endpoints.tocEndpoint;
       },
       returnToRootPayload() {
         return this.context == 'tocs'
           ? { path: 'tocs' }
           : { path: 'reader', query: { urn: this.passage.absolute } };
       },
-      endpoint() {
-        return this.$scaife.endpoints.tocEndpoint;
+      showingRootToc() {
+        if (this.context == 'tocs') {
+          return !this.$route.query.urn;
+        }
+        if (this.$route.query.toc) {
+          return this.$route.query.toc === this.defaultTocUrn ? true : false;
+        }
+        return this.defaultTocUrn
+          ? this.url === this.getTocUrl(this.defaultTocUrn)
+          : this.url === this.getTocUrl(this.rootTocUrn);
       },
       defaultTocUrn() {
         return this.metadata && this.metadata.defaultTocUrn
           ? this.metadata.defaultTocUrn
-          : this.rootTocUrn;
+          : null;
       },
       rootTocUrn() {
         return 'urn:cite:scaife-viewer:toc.demo-root';
-      },
-      rootTocUrl() {
-        return this.getTocUrl(this.rootTocUrn);
       },
       url() {
         if (this.$route.query.toc) {
           return this.getTocUrl(this.$route.query.toc);
         }
         if (this.context === 'reader') {
-          return this.getTocUrl(this.defaultTocUrn);
+          return this.getTocUrl(this.defaultTocUrn || this.rootTocUrn);
         }
-        const urn = this.$route.query.urn
-          ? this.$route.query.urn
-          : this.rootTocUrn;
-        return this.getTocUrl(urn);
+        return this.getTocUrl(this.$route.query.urn || this.rootTocUrn);
       },
     },
     methods: {

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -7,12 +7,21 @@
         :data="toc"
         @filter-data="filterData"
       />
-      <Icon class="root-toc-icon" name="home" v-if="showingRootToc" disabled />
-      <router-link class="root-toc-icon" :to="returnToRootPayload" v-else>
+      <Icon class="icon" name="home" v-if="showingRootToc" disabled />
+      <router-link class="icon" :to="returnToRootPayload" v-else>
         <Icon name="home" />
       </router-link>
+      <span @click.prevent="toggleURNs">
+        <Icon class="icon urn" name="eye" v-if="!showURNs" />
+        <Icon class="icon urn" name="eye-slash" v-else />
+      </span>
     </div>
-    <TOC :toc="filtered || toc" :context="context" :passage="passage" />
+    <TOC
+      :toc="filtered || toc"
+      :context="context"
+      :passage="passage"
+      :showURNs="showURNs"
+    />
   </div>
 </template>
 
@@ -44,6 +53,7 @@
       return {
         toc: null,
         filtered: null,
+        showURNs: false,
       };
     },
     computed: {
@@ -100,6 +110,9 @@
       },
     },
     methods: {
+      toggleURNs() {
+        this.showURNs = !this.showURNs;
+      },
       filterData(data) {
         this.filtered = data;
       },
@@ -135,8 +148,11 @@
       width: 90%;
     }
   }
-  .root-toc-icon {
+  .icon {
     color: black;
     margin-left: 0.66em;
+    &.urn {
+      cursor: pointer;
+    }
   }
 </style>

--- a/tests/components/Paginator.spec.js
+++ b/tests/components/Paginator.spec.js
@@ -33,7 +33,7 @@ describe('Paginator.vue', () => {
     });
     expect(wrapper.html()).toContain(
       // eslint-disable-next-line max-len
-      `<nav class="paginator"><a><icon-stub name="${expected}" fixed-width=""></icon-stub></a></nav>`,
+      `<nav class="paginator"><a><icon-stub name="${expected}"></icon-stub></a></nav>`,
     );
   });
 
@@ -47,7 +47,7 @@ describe('Paginator.vue', () => {
     });
 
     expect(wrapper.html()).toBe(
-      '<nav class="paginator"><a><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-left" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" class="svg-inline--fa fa-chevron-left fa-w-10 fa-fw" fixed-width=""><path fill="currentColor" d="M34.52 239.03L228.87 44.69c9.37-9.37 24.57-9.37 33.94 0l22.67 22.67c9.36 9.36 9.37 24.52.04 33.9L131.49 256l154.02 154.75c9.34 9.38 9.32 24.54-.04 33.9l-22.67 22.67c-9.37 9.37-24.57 9.37-33.94 0L34.52 272.97c-9.37-9.37-9.37-24.57 0-33.94z" class=""></path></svg></a></nav>',
+      '<nav class="paginator"><a><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-left" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" class="svg-inline--fa fa-chevron-left fa-w-10 fa-fw"><path fill="currentColor" d="M34.52 239.03L228.87 44.69c9.37-9.37 24.57-9.37 33.94 0l22.67 22.67c9.36 9.36 9.37 24.52.04 33.9L131.49 256l154.02 154.75c9.34 9.38 9.32 24.54-.04 33.9l-22.67 22.67c-9.37 9.37-24.57 9.37-33.94 0L34.52 272.97c-9.37-9.37-9.37-24.57 0-33.94z" class=""></path></svg></a></nav>',
     );
   });
 });

--- a/tests/components/TOC.spec.js
+++ b/tests/components/TOC.spec.js
@@ -23,9 +23,11 @@ const toc = {
 
 describe('TOC.vue', () => {
   it('It renders a toc on a Reader.', () => {
+    const $route = { name: 'reader', query: {} };
     const wrapper = shallowMount(TOC, {
       propsData: { toc, passage, context: 'reader' },
       stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
     });
 
     expect(wrapper.html()).toContain('<h3>Some Table of Contents</h3>');
@@ -61,9 +63,11 @@ describe('TOC.vue', () => {
   });
 
   it('Identifies URNs correctly.', () => {
+    const $route = { name: 'reader', query: {} };
     const wrapper = shallowMount(TOC, {
       propsData: { toc, passage, context: 'reader' },
       stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
     });
 
     expect(wrapper.vm.isCiteUrn('urn:cite:scaife-viewer:1.1:')).toBe(true);
@@ -71,9 +75,11 @@ describe('TOC.vue', () => {
   });
 
   it('Parses a CTS payload correctly in a reader context.', () => {
+    const $route = { name: 'reader', query: {} };
     const wrapper = shallowMount(TOC, {
       propsData: { toc, passage, context: 'reader' },
       stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
     });
 
     const urn = 'urn:cts:1:1.1.2:1-2';
@@ -83,10 +89,30 @@ describe('TOC.vue', () => {
     });
   });
 
-  it('Parses a CITE payload correctly in a reader context.', () => {
+  it('Parses a CTS payload and preserves a TOC query parameter.', () => {
+    const $route = {
+      name: 'reader',
+      query: { toc: 'urn:cite:scaife-viewer:1.1:' },
+    };
     const wrapper = shallowMount(TOC, {
       propsData: { toc, passage, context: 'reader' },
       stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
+    });
+
+    const urn = 'urn:cts:1:1.1.2:1-2';
+    expect(wrapper.vm.getPayload(urn)).toEqual({
+      path: 'reader',
+      query: { urn, toc: 'urn:cite:scaife-viewer:1.1:' },
+    });
+  });
+
+  it('Parses a CITE payload correctly in a reader context.', () => {
+    const $route = { name: 'reader', query: {} };
+    const wrapper = shallowMount(TOC, {
+      propsData: { toc, passage, context: 'reader' },
+      stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
     });
 
     const urn = 'urn:cite:scaife-viewer:1.1:';
@@ -97,9 +123,11 @@ describe('TOC.vue', () => {
   });
 
   it('Parses a CTS payload correctly in a TOCs context.', () => {
+    const $route = { name: 'tocs', query: {} };
     const wrapper = shallowMount(TOC, {
       propsData: { toc, passage, context: 'tocs' },
       stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
     });
 
     const urn = 'urn:cts:1:1.1.2:1-2';
@@ -110,9 +138,11 @@ describe('TOC.vue', () => {
   });
 
   it('Parses a CITE payload correctly in a TOCs context.', () => {
+    const $route = { name: 'tocs', query: {} };
     const wrapper = shallowMount(TOC, {
       propsData: { toc, passage, context: 'tocs' },
       stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
     });
 
     const urn = 'urn:cite:scaife-viewer:1.1.1:';

--- a/tests/components/TOC.spec.js
+++ b/tests/components/TOC.spec.js
@@ -22,23 +22,24 @@ const toc = {
 };
 
 describe('TOC.vue', () => {
-  it('It renders a toc on a Reader.', () => {
+  it('It renders a toc on a Reader with URNs.', () => {
     const $route = { name: 'reader', query: {} };
     const wrapper = shallowMount(TOC, {
-      propsData: { toc, passage, context: 'reader' },
+      propsData: { toc, passage, context: 'reader', showURNs: true },
       stubs: { RouterLink: RouterLinkStub },
       mocks: { $route },
     });
 
-    expect(wrapper.html()).toContain('<h3>Some Table of Contents</h3>');
-    expect(wrapper.html()).toContain(
-      '<p>A test fixture for a table of contents.</p>',
-    );
+    const header = wrapper.find('h3');
+    expect(header.text()).toEqual('Some Table of Contents');
 
-    const refs = wrapper.findAll('span');
-    expect(refs.length).toBe(4);
+    const legend = wrapper.find('p');
+    expect(legend.text()).toEqual('A test fixture for a table of contents.');
+
+    const refs = wrapper.findAll('span.ref');
+    expect(refs.length).toBe(2);
     expect(refs.at(0).text()).toBe('1.');
-    expect(refs.at(2).text()).toBe('2.');
+    expect(refs.at(1).text()).toBe('2.');
 
     const titles = wrapper.findAll('a');
     expect(titles.length).toBe(2);
@@ -60,6 +61,45 @@ describe('TOC.vue', () => {
     expect(urns.length).toBe(2);
     expect(urns.at(0).text()).toBe('urn:cite:scaife-viewer:1.1:');
     expect(urns.at(1).text()).toBe('urn:cts:1:1.1.2:1-2');
+  });
+
+  it('It renders a toc on a Reader without URNs.', () => {
+    const $route = { name: 'reader', query: {} };
+    const wrapper = shallowMount(TOC, {
+      propsData: { toc, passage, context: 'reader', showURNs: false },
+      stubs: { RouterLink: RouterLinkStub },
+      mocks: { $route },
+    });
+
+    const header = wrapper.find('h3');
+    expect(header.text()).toEqual('Some Table of Contents');
+
+    const legend = wrapper.find('p');
+    expect(legend.text()).toEqual('A test fixture for a table of contents.');
+
+    const refs = wrapper.findAll('span.ref');
+    expect(refs.length).toBe(2);
+    expect(refs.at(0).text()).toBe('1.');
+    expect(refs.at(1).text()).toBe('2.');
+
+    const titles = wrapper.findAll('a');
+    expect(titles.length).toBe(2);
+    expect(titles.at(0).text()).toBe('Title 1');
+    expect(titles.at(0).props('to')).toEqual({
+      path: 'reader',
+      query: {
+        urn: 'urn:cts:1:1.1.3:1-2',
+        toc: 'urn:cite:scaife-viewer:1.1:',
+      },
+    });
+    expect(titles.at(1).text()).toBe('Title 2');
+    expect(titles.at(1).props('to')).toEqual({
+      path: 'reader',
+      query: { urn: 'urn:cts:1:1.1.2:1-2' },
+    });
+
+    const urns = wrapper.findAll('tt');
+    expect(urns.length).toBe(0);
   });
 
   it('Identifies URNs correctly.', () => {

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -1,5 +1,5 @@
 /* global jest, describe, expect, it  */
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { shallowMount, createLocalVue, RouterLinkStub } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import scaifeWidgets from '@/store';
@@ -43,6 +43,7 @@ describe('TOCWidget.vue', () => {
     const wrapper = shallowMount(TOCWidget, {
       store,
       localVue,
+      stubs: { RouterLink: RouterLinkStub },
       mocks: { $route, $scaife },
       computed: {
         passage() {
@@ -72,6 +73,7 @@ describe('TOCWidget.vue', () => {
     const wrapper = shallowMount(TOCWidget, {
       store,
       localVue,
+      stubs: { RouterLink: RouterLinkStub },
       mocks: { $route, $scaife },
       computed: {
         passage() {
@@ -97,7 +99,7 @@ describe('TOCWidget.vue', () => {
 
   it('Renders a lookahead on the reader.', () => {
     const fetchData = jest.fn();
-    const $route = { name: 'tocs' };
+    const $route = { name: 'tocs', query: {} };
 
     const store = new Vuex.Store({
       modules: {
@@ -108,6 +110,7 @@ describe('TOCWidget.vue', () => {
       store,
       localVue,
       methods: { fetchData },
+      stubs: { RouterLink: RouterLinkStub },
       mocks: { $route },
     });
     wrapper.setData({ toc });
@@ -134,6 +137,7 @@ describe('TOCWidget.vue', () => {
     const wrapper = shallowMount(TOCWidget, {
       store,
       localVue,
+      stubs: { RouterLink: RouterLinkStub },
       mocks: { $route, $scaife },
       computed: {
         passage() {
@@ -173,6 +177,7 @@ describe('TOCWidget.vue', () => {
     const wrapper = shallowMount(TOCWidget, {
       store,
       localVue,
+      stubs: { RouterLink: RouterLinkStub },
       mocks: { $route, $scaife },
       computed: {
         passage() {
@@ -215,6 +220,7 @@ describe('TOCWidget.vue', () => {
     const wrapper = shallowMount(TOCWidget, {
       store,
       localVue,
+      stubs: { RouterLink: RouterLinkStub },
       mocks: { $route, $scaife },
       computed: {
         passage() {

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -94,6 +94,7 @@ describe('TOCWidget.vue', () => {
       toc,
       passage,
       context: 'reader',
+      showURNs: false,
     });
   });
 
@@ -158,6 +159,7 @@ describe('TOCWidget.vue', () => {
       toc,
       passage: null,
       context: 'tocs',
+      showURNs: false,
     });
   });
 
@@ -198,6 +200,7 @@ describe('TOCWidget.vue', () => {
       toc,
       passage: null,
       context: 'tocs',
+      showURNs: false,
     });
   });
 
@@ -239,6 +242,7 @@ describe('TOCWidget.vue', () => {
       toc,
       passage,
       context: 'reader',
+      showURNs: false,
     });
   });
 });

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -29,6 +29,96 @@ const toc = {
   ],
 };
 
+describe('TOCWidget.vue computed', () => {
+  it('The TOC knows when it is showing the root TOC.', () => {
+    const localThis = { context: 'tocs', $route: { path: 'tocs', query: {} } };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(true);
+  });
+
+  it('The TOC knows when it is not showing the root TOC.', () => {
+    const localThis = {
+      context: 'tocs',
+      $route: {
+        path: 'tocs',
+        query: { urn: 'urn:cite:scaife-viewer:toc.not-root-1' },
+      },
+    };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(false);
+  });
+
+  it('The Reader knows the query and default TOCs are the same.', () => {
+    const localThis = {
+      context: 'reader',
+      $route: {
+        path: 'reader',
+        query: { toc: 'urn:cite:scaife-viewer:toc.oaf-1' },
+      },
+      defaultTocUrn: 'urn:cite:scaife-viewer:toc.oaf-1',
+    };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(true);
+  });
+
+  it('The Reader knows the query and default TOCs are different.', () => {
+    const localThis = {
+      context: 'reader',
+      $route: {
+        path: 'reader',
+        query: { toc: 'urn:cite:scaife-viewer:toc.not-default' },
+      },
+      defaultTocUrn: 'urn:cite:scaife-viewer:toc.oaf-1',
+    };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(false);
+  });
+
+  it('The Reader knows when it is showing the default TOC.', () => {
+    const localThis = {
+      context: 'reader',
+      $route: { path: 'reader', query: {} },
+      defaultTocUrn: 'urn:cite:scaife-viewer:toc.oaf-1',
+      endpoint: 'example.com',
+      getTocUrl: TOCWidget.methods.getTocUrl,
+      url: 'example.com/tocs/toc.oaf-1.json',
+    };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(true);
+  });
+
+  it('The Reader knows when it is not showing the default TOC.', () => {
+    const localThis = {
+      context: 'reader',
+      $route: { path: 'reader', query: {} },
+      defaultTocUrn: 'urn:cite:scaife-viewer:toc.oaf-1',
+      endpoint: 'example.com',
+      getTocUrl: TOCWidget.methods.getTocUrl,
+      url: 'example.com/tocs/toc.not-default.json',
+    };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(false);
+  });
+
+  it('The Reader knows when it is showing the root TOC.', () => {
+    const localThis = {
+      context: 'reader',
+      $route: { path: 'reader', query: {} },
+      endpoint: 'example.com',
+      getTocUrl: TOCWidget.methods.getTocUrl,
+      rootTocUrn: 'urn:cite:scaife-viewer:toc.demo-root',
+      url: 'example.com/tocs/toc.demo-root.json',
+    };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(true);
+  });
+
+  it('The Reader knows when it is not showing the root TOC.', () => {
+    const localThis = {
+      context: 'reader',
+      $route: { path: 'reader', query: {} },
+      endpoint: 'example.com',
+      getTocUrl: TOCWidget.methods.getTocUrl,
+      rootTocUrn: 'urn:cite:scaife-viewer:toc.demo-root',
+      url: 'example.com/tocs/toc.not-root.json',
+    };
+    expect(TOCWidget.computed.showingRootToc.call(localThis)).toBe(false);
+  });
+});
+
 describe('TOCWidget.vue', () => {
   it('Parses a URL and catches a failed request.', async () => {
     const $route = { name: 'reader', query: {} };


### PR DESCRIPTION
### Tickets
- https://trello.com/c/nTcfbxtm/50-as-a-reader-i-can-navigate-to-other-tocs-from-a-toc
- https://trello.com/c/W9tVMvsR/60-as-a-reader-i-can-return-to-the-root-toc
- https://trello.com/c/oEd9LLtQ/85-toc-style-tweaks

### Implements
- Utilise URL parameters to implement different TOC navigation strategies depending if a user is in the context of the `Reader` or the `TOCs` list page.
- A benefit of this approach is that it meshes with our previous conversations about having the total state of the app be recoverable from a URL. So, although this won't preserve the history of navigating through TOCs whilst in the `Reader`, if you return to a particular URL it will remember the TOC you had loaded at that particular moment.
- For example, the below screenshot corresponds to the URL:

http://localhost:8080/reader?urn=urn%3Acts%3AgreekLit%3Atlg1271.tlg001.oaf-1%3A0-1&toc=urn%3Acite%3Ascaife-viewer%3Atoc.crito-stephanus-jkt-1

<img width="2672" alt="Screenshot 2020-03-02 14 48 11" src="https://user-images.githubusercontent.com/1431010/75682013-fdba9480-5c94-11ea-884f-53efccce703f.png">

- Add a return to TOC root anchor and derive the appropriate logic for that in each context (eithjer on the `Reader` route or `TOCs` route).
- Disable the anchor when the root TOC is in effect.

<img width="2672" alt="Screenshot 2020-03-02 14 48 20" src="https://user-images.githubusercontent.com/1431010/75682022-01e6b200-5c95-11ea-9ea2-dd061d073a96.png">

- Style tweaks from [#85](https://trello.com/c/oEd9LLtQ/85-toc-style-tweaks).