### PR TITLE
Refer to Lookahead filtering as "Filter", not "Search"

### DIFF
--- a/src/components/Lookahead.vue
+++ b/src/components/Lookahead.vue
@@ -2,7 +2,6 @@
   <div class="form-group">
     <div class="input-group u-flex">
       <input
-        type="search"
         class="form-control"
         v-model="query"
         :placeholder="placeholder"

--- a/src/widgets/TOCWidget.vue
+++ b/src/widgets/TOCWidget.vue
@@ -61,7 +61,7 @@
         return this.$route.name;
       },
       placeholder() {
-        return 'Search this table of contents...';
+        return 'Filter this table of contents...';
       },
       passage() {
         return this.$store.getters[`${WIDGETS_NS}/passage`];

--- a/tests/widgets/TOCWidget.spec.js
+++ b/tests/widgets/TOCWidget.spec.js
@@ -210,7 +210,7 @@ describe('TOCWidget.vue', () => {
     expect(lookahead.exists()).toBeTruthy();
     expect(lookahead.props()).toEqual({
       data: toc,
-      placeholder: 'Search this table of contents...',
+      placeholder: 'Filter this table of contents...',
       reducer: wrapper.vm.reducer,
     });
   });


### PR DESCRIPTION
Also ensures we style `input` consistently with other filtering inputs (like the word list widget)