### PR TITLE
Library widget improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,15 @@
+const defaultRules = {
+  'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+  'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+  'vue/script-indent': ['error', 2, { baseIndent: 1 }],
+  'max-len': [2, { code: 80, tabWidth: 2, ignoreUrls: true }],
+};
+
+if (process.env.npm_lifecycle_event === 'watch') {
+  defaultRules['no-console'] = 'off';
+  defaultRules['no-debugger'] = 'off';
+}
+
 module.exports = {
   root: true,
 
@@ -5,12 +17,7 @@ module.exports = {
     node: true,
   },
 
-  rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'vue/script-indent': ['error', 2, { baseIndent: 1 }],
-    'max-len': [2, { code: 80, tabWidth: 2, ignoreUrls: true }],
-  },
+  rules: defaultRules,
 
   parserOptions: {
     parser: 'babel-eslint',

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -14,7 +14,7 @@
           {{ metadata.label }}
         </router-link>
       </span>
-      <span v-else class="node monospace">
+      <span v-else class="node parent">
         <tt>{{ metadata.label }}</tt>
       </span>
     </div>
@@ -89,6 +89,12 @@
   .node {
     &.version {
       margin-left: 1em;
+      font-size: 0.8em;
+    }
+    &.parent {
+      > tt {
+        font-family: inherit;
+      }
     }
   }
 </style>

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -11,11 +11,11 @@
         <router-link
           :to="{ path: 'reader', query: { urn: metadata.firstPassageUrn } }"
         >
-          {{ metadata.workTitle }}
+          {{ metadata.label }}
         </router-link>
       </span>
       <span v-else class="node monospace">
-        <tt>{{ urn }}</tt>
+        <tt>{{ metadata.label }}</tt>
       </span>
     </div>
 

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -27,14 +27,20 @@
       isCiteUrn(urn) {
         return urn.startsWith('urn:cite:');
       },
+      getCitePayloadInTocsContext(urn) {
+        return { path: 'tocs', query: { urn } };
+      },
+      getCitePayloadInReaderContext(urn) {
+        return {
+          path: 'reader',
+          query: { urn: this.passage.toString(), toc: urn.toString() },
+        };
+      },
       getPayload(urn) {
         if (this.isCiteUrn(urn)) {
           return this.context === 'tocs'
-            ? { path: 'tocs', query: { urn } }
-            : {
-              path: 'reader',
-              query: { urn: this.passage.toString(), toc: urn.toString() },
-            };
+            ? this.getCitePayloadInTocsContext(urn)
+            : this.getCitePayloadInReaderContext(urn);
         }
         return this.$route.query.toc
           ? { path: 'reader', query: { urn, toc: this.$route.query.toc } }

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -6,7 +6,5 @@ export default {
   passage: (state, getters, rootState, rootGetters) => rootGetters.passage,
   firstPassageUrn: (state, getters, rootState, rootGetters) =>
     rootGetters.firstPassageUrn,
-  libraryTree: (state, getters, rootState, rootGetters) =>
-    rootGetters.libraryTree,
   metadata: (state, getters, rootState, rootGetters) => rootGetters.metadata,
 };

--- a/src/widgets/LibraryWidget.vue
+++ b/src/widgets/LibraryWidget.vue
@@ -8,7 +8,7 @@
 
 <script>
   import Node from '@/components/Node.vue';
-  import { WIDGETS_NS } from '@/store/constants';
+  import gql from 'graphql-tag';
 
   export default {
     name: 'LibraryWidget',
@@ -18,9 +18,26 @@
     scaifeConfig: {
       displayName: 'Library',
     },
+    methods: {
+      getTextGroupsTree() {
+        const nid = this.gqlData.tree.tree[0];
+        return nid.children.reduce((a, b) => {
+          return a.concat(b.children);
+        }, []);
+      },
+    },
     computed: {
+      gqlQuery() {
+        return gql`
+          {
+            tree(urn: "urn:cts:", upTo: "version") {
+              tree
+            }
+          }
+        `;
+      },
       libraryTree() {
-        return this.$store.getters[`${WIDGETS_NS}/libraryTree`];
+        return this.gqlData ? this.getTextGroupsTree() : [];
       },
     },
   };

--- a/src/widgets/NewAlexandriaWidget.vue
+++ b/src/widgets/NewAlexandriaWidget.vue
@@ -42,9 +42,7 @@
         return 'https://commentary-api.chs.harvard.edu/graphql';
       },
       params() {
-        return this.passage
-          ? qs.stringify({
-            query: `{
+        const gqlQuery = `{
           commentsOn(urn: "${this.passage}") {
             _id
             updated
@@ -57,9 +55,8 @@
               name
             }
           }
-        }`,
-          })
-          : null;
+        }`;
+        return this.passage ? qs.stringify({ query: gqlQuery }) : null;
       },
       url() {
         return `${this.endpoint}?${this.params}`;

--- a/tests/components/Node.spec.js
+++ b/tests/components/Node.spec.js
@@ -16,7 +16,7 @@ describe('Node.vue', () => {
 
     expect(wrapper.html()).not.toContain('<span class="open-toggle"');
     expect(wrapper.html()).toContain(
-      '<span class="node monospace"><tt>urn:cts:1:</tt></span>',
+      '<span class="node parent"><tt>urn:cts:1:</tt></span>',
     );
     expect(wrapper.html()).not.toContain('<a>');
     expect(wrapper.html()).not.toContain('<ul class="node-tree"');
@@ -80,10 +80,10 @@ describe('Node.vue', () => {
 
     const spans = wrapper.findAll('span');
     expect(spans.at(0).classes()).toEqual(['open-toggle']);
-    expect(spans.at(1).classes()).toEqual(['node', 'monospace']);
-    const monospace = wrapper.findAll('tt');
-    expect(monospace.length).toBe(1);
-    expect(monospace.at(0).text()).toBe('urn:cts:1:1.1:');
+    expect(spans.at(1).classes()).toEqual(['node', 'parent']);
+    const parent = wrapper.findAll('tt');
+    expect(parent.length).toBe(1);
+    expect(parent.at(0).text()).toBe('urn:cts:1:1.1:');
 
     const childList = wrapper.findAll('ul');
     expect(childList.length).toBe(0);
@@ -122,10 +122,10 @@ describe('Node.vue', () => {
 
     const spans = wrapper.findAll('span');
     expect(spans.at(0).classes()).toEqual(['open-toggle']);
-    expect(spans.at(1).classes()).toEqual(['node', 'monospace']);
-    const monospace = wrapper.findAll('tt');
-    expect(monospace.length).toBe(1);
-    expect(monospace.at(0).text()).toBe('urn:cts:1:1.1:');
+    expect(spans.at(1).classes()).toEqual(['node', 'parent']);
+    const parent = wrapper.findAll('tt');
+    expect(parent.length).toBe(1);
+    expect(parent.at(0).text()).toBe('urn:cts:1:1.1:');
 
     const childList = wrapper.findAll('ul');
     expect(childList.length).toBe(1);

--- a/tests/components/Node.spec.js
+++ b/tests/components/Node.spec.js
@@ -5,7 +5,11 @@ import Node from '@/components/Node.vue';
 describe('Node.vue', () => {
   it('It renders nodes without children.', () => {
     const node = {
-      data: { urn: 'urn:cts:1:', kind: 'node', metadata: {} },
+      data: {
+        urn: 'urn:cts:1:',
+        kind: 'node',
+        metadata: { label: 'urn:cts:1:' },
+      },
       children: [],
     };
     const wrapper = shallowMount(Node, { propsData: { node } });
@@ -24,7 +28,7 @@ describe('Node.vue', () => {
         urn: 'urn:cts:1:1.1.1:',
         kind: 'version',
         metadata: {
-          workTitle: 'some title',
+          label: 'some title',
           firstPassageUrn: 'urn:cts:1:1.1.1:1',
         },
       },
@@ -50,14 +54,18 @@ describe('Node.vue', () => {
 
   it('It does not render children when parent node not expanded.', () => {
     const node = {
-      data: { urn: 'urn:cts:1:1.1:', kind: 'node', metadata: {} },
+      data: {
+        urn: 'urn:cts:1:1.1:',
+        kind: 'node',
+        metadata: { label: 'urn:cts:1:1.1:' },
+      },
       children: [
         {
           data: {
             urn: 'urn:cts:1:1.1.1:',
             kind: 'version',
             metadata: {
-              workTitle: 'some title',
+              label: 'some title',
               firstPassageUrn: 'urn:cts:1:1.1.1:1',
             },
           },
@@ -83,14 +91,18 @@ describe('Node.vue', () => {
 
   it('It renders all nodes when expanded.', async () => {
     const node = {
-      data: { urn: 'urn:cts:1:1.1:', kind: 'node', metadata: {} },
+      data: {
+        urn: 'urn:cts:1:1.1:',
+        kind: 'node',
+        metadata: { label: 'urn:cts:1:1.1:' },
+      },
       children: [
         {
           data: {
             urn: 'urn:cts:1:1.1.1:',
             kind: 'version',
             metadata: {
-              workTitle: 'some title',
+              label: 'some title',
               firstPassageUrn: 'urn:cts:1:1.1.1:1',
             },
           },

--- a/tests/widgets/PassageAncestorsWidget.spec.js
+++ b/tests/widgets/PassageAncestorsWidget.spec.js
@@ -27,6 +27,7 @@ describe('PassageAncestorsWidget.vue', () => {
     });
 
     expect(wrapper.html()).toBe(
+      // eslint-disable-next-line max-len
       '<div class="passage-ancestors-widget u-widget"><ol class="ancestors"></ol></div>',
     );
   });


### PR DESCRIPTION
## What's in this PR?

This PR updates the library widget to display the labels for the text groups, works, and versions.

Labels are set within ATLAS as part of ingestion and sent in the `metadata` field for each node.

## Other Fixes

- Disable `no-console` and `no-debugger` rules when developing the package via `yarn watch`
- Fixes errors reported by `yarn lint`