### PR TITLE
Passage / version metadata improvements

### DIFF
--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -1,8 +1,16 @@
 <template>
-  <aside class="metadata-container u-flex">
-    <h3 class="work-title">{{ metadata.workTitle }}</h3>
-    <tt class="work-urn">{{ metadata.workUrn }}</tt>
-  </aside>
+  <dl class="metadata-container u-flex">
+    <dt>Text Group:</dt>
+    <dd>{{ metadata.textGroupLabel }}</dd>
+    <dt>Work:</dt>
+    <dd>{{ metadata.workLabel }}</dd>
+    <dt>Version:</dt>
+    <dd>{{ metadata.label }}</dd>
+    <dt>Language:</dt>
+    <dd>{{ metadata.humanLang }}</dd>
+    <dt>URN:</dt>
+    <dd>{{ metadata.versionUrn }}</dd>
+  </dl>
 </template>
 
 <script>
@@ -16,7 +24,7 @@
   .metadata-container {
     flex-direction: column;
     > * {
-      margin: 0 0 0.33em 0;
+      font-size: 0.8em;
     }
   }
 </style>

--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -1,16 +1,26 @@
 <template>
-  <dl class="metadata-container u-flex">
-    <dt>Text Group:</dt>
-    <dd>{{ metadata.textGroupLabel }}</dd>
-    <dt>Work:</dt>
-    <dd>{{ metadata.workLabel }}</dd>
-    <dt>Version:</dt>
-    <dd>{{ metadata.label }}</dd>
-    <dt>Language:</dt>
-    <dd>{{ metadata.humanLang }}</dd>
-    <dt>URN:</dt>
-    <dd>{{ versionUrn }}</dd>
-  </dl>
+<div class="metadata-container u-flex">
+    <div class="metadata-row">
+      <div class="label">Text Group:</div>
+      <div class="value">{{ metadata.textGroupLabel }}</div>
+    </div>
+    <div class="metadata-row">
+      <div class="label">Work:</div>
+      <div class="value">{{ metadata.workLabel }}</div>
+    </div>
+    <div class="metadata-row">
+      <div class="label">Version:</div>
+      <div class="value">{{ metadata.label }}</div>
+    </div>
+    <div class="metadata-row">
+      <div class="label">Language:</div>
+      <div class="value">{{ metadata.humanLang }}</div>
+    </div>
+    <div class="metadata-row">
+      <div class="label">URN:</div>
+      <tt class="version-urn">{{ versionUrn }}</tt>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -24,7 +34,20 @@
   .metadata-container {
     flex-direction: column;
     > * {
-      font-size: 0.8em;
+      font-size: 14px;
+    }
+    .metadata-row {
+      > .label {
+        color: $gray-600;
+      }
+      > .value {
+        font-family: $font-family-serif;
+      }
+      > .version-urn, .value {
+        margin-top: 0.25em;
+      }
+      flex-flow: row nowrap;
+      margin: 0.5em 0;
     }
   }
 </style>

--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="metadata-container u-flex">
+  <div class="metadata-container u-flex">
     <div class="metadata-row">
       <div class="label">Text Group:</div>
       <div class="value">{{ metadata.textGroupLabel }}</div>
@@ -43,7 +43,8 @@
       > .value {
         font-family: $font-family-serif;
       }
-      > .version-urn, .value {
+      > .version-urn,
+      .value {
         margin-top: 0.25em;
       }
       flex-flow: row nowrap;

--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -9,14 +9,14 @@
     <dt>Language:</dt>
     <dd>{{ metadata.humanLang }}</dd>
     <dt>URN:</dt>
-    <dd>{{ metadata.versionUrn }}</dd>
+    <dd>{{ versionUrn }}</dd>
   </dl>
 </template>
 
 <script>
   export default {
     name: 'Metadata',
-    props: ['metadata'],
+    props: ['metadata', 'versionUrn'],
   };
 </script>
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ export { default as NewAlexandriaWidget } from '@/widgets/NewAlexandriaWidget.vu
 // eslint-disable-next-line max-len
 export { default as PassageAncestorsWidget } from '@/widgets/PassageAncestorsWidget.vue';
 // eslint-disable-next-line max-len
+export { default as PassageSiblingsWidget } from '@/widgets/PassageSiblingsWidget.vue';
+// eslint-disable-next-line max-len
 export { default as PassageChildrenWidget } from '@/widgets/PassageChildrenWidget.vue';
 // eslint-disable-next-line max-len
 export { default as PassageReferenceWidget } from '@/widgets/PassageReferenceWidget.vue';

--- a/src/utils/URN.js
+++ b/src/utils/URN.js
@@ -20,4 +20,13 @@ export default class URN {
   toString() {
     return this.absolute;
   }
+
+  get lsb() {
+    return this.reference
+      ? this.reference
+          .split('-')[0]
+          .split('.')
+          .slice(-1)[0]
+      : null;
+  }
 }

--- a/src/utils/URN.js
+++ b/src/utils/URN.js
@@ -21,7 +21,7 @@ export default class URN {
     return this.absolute;
   }
 
-  get lsb() {
+  get lcp() {
     return this.reference
       ? this.reference
           .split('-')[0]

--- a/src/widgets/MetadataWidget.vue
+++ b/src/widgets/MetadataWidget.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="metadata-widget u-widget u-flex">
-    <Metadata v-if="metadata" :metadata="metadata" />
+    <Metadata v-if="metadata" :metadata="metadata" :version-urn="versionUrn" />
   </div>
 </template>
 
@@ -20,11 +20,11 @@
       passage() {
         return this.$store.getters[`${WIDGETS_NS}/passage`];
       },
+      versionUrn() {
+        return this.passage.version;
+      },
       metadata() {
-        return {
-          ...this.$store.getters[`${WIDGETS_NS}/metadata`],
-          versionUrn: this.passage.version,
-        };
+        return this.$store.getters[`${WIDGETS_NS}/metadata`];
       },
     },
   };
@@ -36,4 +36,3 @@
     width: 100%;
   }
 </style>
-

--- a/src/widgets/MetadataWidget.vue
+++ b/src/widgets/MetadataWidget.vue
@@ -17,8 +17,14 @@
       displayName: 'Metadata',
     },
     computed: {
+      passage() {
+        return this.$store.getters[`${WIDGETS_NS}/passage`];
+      },
       metadata() {
-        return this.$store.getters[`${WIDGETS_NS}/metadata`];
+        return {
+          ...this.$store.getters[`${WIDGETS_NS}/metadata`],
+          versionUrn: this.passage.version,
+        };
       },
     },
   };
@@ -30,3 +36,4 @@
     width: 100%;
   }
 </style>
+

--- a/src/widgets/PassageAncestorsWidget.vue
+++ b/src/widgets/PassageAncestorsWidget.vue
@@ -57,7 +57,7 @@
   }
   .passage-ancestors-widget * {
     display: flex;
-    font-size: 0.75rem;
+    font-size: 0.7rem;
   }
   .passage-ancestors-widget a {
     border: none;

--- a/src/widgets/PassageChildrenWidget.vue
+++ b/src/widgets/PassageChildrenWidget.vue
@@ -51,14 +51,13 @@
     width: 100%;
     grid-auto-rows: 1fr;
     grid-template-columns: repeat(auto-fill, minmax(1.6em, 1fr));
-    grid-gap: 0.0825em;
   }
   .passage-children-widget * {
     display: flex;
     justify-content: center;
     align-items: center;
-    border: 1px solid #e9ecef;
-    font-size: 0.8rem;
+    font-size: 0.7rem;
+    padding: 0.1rem 0.3rem;
   }
   .passage-children-widget a {
     border: none;

--- a/src/widgets/PassageChildrenWidget.vue
+++ b/src/widgets/PassageChildrenWidget.vue
@@ -2,7 +2,7 @@
   <div class="passage-children-widget u-widget u-grid">
     <div class="grid-cell-square" v-for="child in children" :key="child.urn">
       <router-link :to="{ path: 'reader', query: { urn: `${child.urn}` } }">
-        {{ child.lsb }}
+        {{ child.lcp }}
       </router-link>
     </div>
   </div>

--- a/src/widgets/PassageSiblingsWidget.vue
+++ b/src/widgets/PassageSiblingsWidget.vue
@@ -5,14 +5,14 @@
       v-for="sibling in siblings"
       :key="sibling.urn"
     >
-      <a v-if="sibling.lsb === passage.lsb" class="active-sibling">
-        {{ sibling.lsb }}
+      <a v-if="sibling.lcp === passage.lcp" class="active-sibling">
+        {{ sibling.lcp }}
       </a>
       <router-link
         v-else
         :to="{ path: 'reader', query: { urn: `${sibling.urn}` } }"
       >
-        {{ sibling.lsb }}
+        {{ sibling.lcp }}
       </router-link>
     </div>
   </div>

--- a/src/widgets/PassageSiblingsWidget.vue
+++ b/src/widgets/PassageSiblingsWidget.vue
@@ -75,6 +75,6 @@
   .active-sibling {
     font-weight: bold;
     color: $white;
-    background: $gray-800;
+    background: var(--scaife-brand-color, $gray-800);
   }
 </style>

--- a/src/widgets/PassageSiblingsWidget.vue
+++ b/src/widgets/PassageSiblingsWidget.vue
@@ -1,0 +1,79 @@
+<template v-if="siblings">
+  <div class="passage-siblings-widget u-widget u-grid">
+    <div
+      class="grid-cell-square"
+      v-for="sibling in siblings"
+      :key="sibling.urn"
+    >
+      <a v-if="sibling.lsb === passage.lsb" class="active-sibling">
+        {{ sibling.lsb }}
+      </a>
+      <router-link
+        v-else
+        :to="{ path: 'reader', query: { urn: `${sibling.urn}` } }"
+      >
+        {{ sibling.lsb }}
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script>
+  import gql from 'graphql-tag';
+  import { WIDGETS_NS } from '@/store/constants';
+
+  export default {
+    name: 'PassageSiblingsWidget',
+    scaifeConfig: {
+      displayName: 'Siblings',
+    },
+    computed: {
+      passage() {
+        return this.$store.getters[`${WIDGETS_NS}/passage`];
+      },
+      gqlQuery() {
+        return this.passage
+          ? gql`
+            {
+              passageTextParts(reference: "${this.passage}") {
+                metadata
+              }
+            }`
+          : null;
+      },
+      siblingsLens() {
+        return this.gqlData.passageTextParts.metadata.siblings;
+      },
+      siblings() {
+        return this.gqlData && this.siblingsLens
+          ? this.siblingsLens.map(node => node)
+          : [];
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  a {
+    text-decoration: none;
+  }
+  .passage-siblings-widget {
+    width: 100%;
+    grid-auto-rows: 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(1.6em, 1fr));
+    grid-gap: 0.0825em;
+  }
+  .passage-siblings-widget * {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid #e9ecef;
+    font-size: 0.8rem;
+  }
+  .passage-siblings-widget a {
+    border: none;
+  }
+  .active-sibling {
+    font-weight: bold;
+  }
+</style>

--- a/src/widgets/PassageSiblingsWidget.vue
+++ b/src/widgets/PassageSiblingsWidget.vue
@@ -61,19 +61,20 @@
     width: 100%;
     grid-auto-rows: 1fr;
     grid-template-columns: repeat(auto-fill, minmax(1.6em, 1fr));
-    grid-gap: 0.0825em;
   }
   .passage-siblings-widget * {
     display: flex;
     justify-content: center;
     align-items: center;
-    border: 1px solid #e9ecef;
-    font-size: 0.8rem;
+    font-size: 0.7rem;
+    padding: 0.1rem 0.3rem;
   }
   .passage-siblings-widget a {
     border: none;
   }
   .active-sibling {
     font-weight: bold;
+    color: $white;
+    background: $gray-800;
   }
 </style>

--- a/tests/components/Metadata.spec.js
+++ b/tests/components/Metadata.spec.js
@@ -3,16 +3,17 @@ import { shallowMount } from '@vue/test-utils';
 import Metadata from '@/components/Metadata.vue';
 
 describe('Metadata.vue', () => {
-  it('it renders the work title', () => {
+  it('it renders the text group label', () => {
     const wrapper = shallowMount(Metadata, {
       propsData: {
-        metadata: { workTitle: 'some title', workUrn: 'urn:cts:1:1.1:' },
+        metadata: { textGroupLabel: 'text group' },
+        versionUrn: 'urn:cts:greekLit:tlg0012.tlg001.msA:',
       },
     });
 
-    expect(wrapper.html()).toContain('<h3 class="work-title">some title</h3>');
+    expect(wrapper.html()).toContain('<div class="value">text group</div>');
     expect(wrapper.html()).toContain(
-      '<tt class="work-urn">urn:cts:1:1.1:</tt>',
+      '<tt class="version-urn">urn:cts:greekLit:tlg0012.tlg001.msA:</tt>',
     );
   });
 });

--- a/tests/widgets/MetadataWidget.spec.js
+++ b/tests/widgets/MetadataWidget.spec.js
@@ -3,6 +3,7 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import scaifeWidgets from '@/store';
+import URN from '@/utils/URN';
 import MetadataWidget from '@/widgets/MetadataWidget.vue';
 import Metadata from '@/components/Metadata.vue';
 
@@ -20,8 +21,14 @@ describe('MetadataWidget.vue', () => {
       store,
       localVue,
       computed: {
+        passage() {
+          return new URN('urn:cts:greekLit:tlg0012.tlg001.msA:1.2.3');
+        },
+        versionUrn() {
+          return 'urn:cts:greekLit:tlg0012.tlg001.msA:';
+        },
         metadata() {
-          return { workTitle: 'some title', workUrn: 'urn:cts:1:1.1:' };
+          return { textGroupLabel: 'text group' };
         },
       },
     });
@@ -29,7 +36,8 @@ describe('MetadataWidget.vue', () => {
     expect(container.classes()).toContain('metadata-widget');
 
     expect(wrapper.find(Metadata).props()).toEqual({
-      metadata: { workTitle: 'some title', workUrn: 'urn:cts:1:1.1:' },
+      metadata: { textGroupLabel: 'text group' },
+      versionUrn: 'urn:cts:greekLit:tlg0012.tlg001.msA:',
     });
   });
 });

--- a/tests/widgets/PassageChildrenWidget.spec.js
+++ b/tests/widgets/PassageChildrenWidget.spec.js
@@ -45,7 +45,7 @@ describe('PassageChildrenWidget.vue', () => {
         children() {
           return [
             {
-              lsb: '1',
+              lcp: '1',
               urn: 'urn:cts:greekLit:tlg0012.tlg001.msA:1.1',
             },
           ];
@@ -81,11 +81,11 @@ describe('PassageChildrenWidget.vue', () => {
         children() {
           return [
             {
-              lsb: '1',
+              lcp: '1',
               urn: 'urn:cts:greekLit:tlg0012.tlg001.msA:1.1',
             },
             {
-              lsb: '2',
+              lcp: '2',
               urn: 'urn:cts:greekLit:tlg0012.tlg001.msA:1.2',
             },
           ];


### PR DESCRIPTION
What's in this PR:

- Expand values shown in Metadata widget
- Add a PassageSiblings widget
- Improve PassageChildren styles
- Prefer lcp (lowest citable part)
- Introduce CSS variables (will break in IE 11, see https://trello.com/c/zustsO0R)

Refs:
- ![](https://github.trello.services/images/mini-trello-icon.png) [Add siblings widget](https://trello.com/c/2Pd9lNwB/132-add-siblings-widget)
- ![](https://github.trello.services/images/mini-trello-icon.png) [Expand what is shown in the metadata widget](https://trello.com/c/lgKWv65L/78-expand-what-is-shown-in-the-metadata-widget)